### PR TITLE
Feat/refactor navigation

### DIFF
--- a/CoreDisc/API/Router/FollowRouter.swift
+++ b/CoreDisc/API/Router/FollowRouter.swift
@@ -49,8 +49,20 @@ extension FollowRouter: APITargetType {
     
     var task: Task {
         switch self {
-        case .postFollow, .getFollowers, .getFollowersTarget, .getFollowings, .getFollowingsTarget, .deleteFollowings:
+        case .postFollow, .deleteFollowings:
             return .requestPlain
+        case .getFollowers(let cursorId, let size),
+                .getFollowersTarget(_, let cursorId, let size),
+                .getFollowings(let cursorId, let size),
+                .getFollowingsTarget(_, let cursorId, let size):
+            var parameters: [String: Any] = [:]
+            if let cursorId = cursorId {
+                parameters["cursorId"] = cursorId
+            }
+            if let size = size {
+                parameters["size"] = size
+            }
+            return .requestParameters(parameters: parameters, encoding: URLEncoding.default)
         }
     }
 }

--- a/CoreDisc/CoreDiscApp.swift
+++ b/CoreDisc/CoreDiscApp.swift
@@ -21,7 +21,7 @@ struct CoreDiscApp: App {
     
     var body: some Scene {
         WindowGroup {
-            LoginView()
+            OnboardingTabContainer()
                 .onOpenURL { url in
                     if (AuthApi.isKakaoTalkLoginUrl(url)) {
                         _ = AuthController.handleOpenUrl(url: url)

--- a/CoreDisc/Responses/MyHome/FollowResponse.swift
+++ b/CoreDisc/Responses/MyHome/FollowResponse.swift
@@ -129,4 +129,5 @@ struct FollowDisplayModel: Identifiable, Hashable {
     let username: String
     let profileImgUrl: String?
     let isCore: Bool
+    let isMutual: Bool?
 }

--- a/CoreDisc/Responses/MyHome/FollowResponse.swift
+++ b/CoreDisc/Responses/MyHome/FollowResponse.swift
@@ -26,6 +26,7 @@ struct FollowerCursor: Decodable {
 }
 
 struct FollowerValues: Decodable {
+    let followId: Int
     let followerId: Int
     let nickname: String
     let username: String
@@ -58,15 +59,11 @@ struct UserFollowerCursor: Decodable {
 }
 
 struct UserFollowerValues: Decodable {
+    let followId: Int
     let followerId: Int
     let nickname: String
     let username: String
     let profileImgDTO: FollowerProfileImgDTO?
-}
-
-struct UserFollowerProfileImgDTO: Decodable {
-    let profileImgId: Int
-    let imageUrl: String
 }
 
 // MARK: - Following
@@ -88,6 +85,7 @@ struct FollowingCursor: Decodable {
 }
 
 struct FollowingValues: Decodable {
+    let followId: Int
     let followingId: Int
     let nickname: String
     let username: String
@@ -124,6 +122,7 @@ struct UnfollowResponse: Decodable {
 
 // MARK: - Common
 struct FollowDisplayModel: Identifiable, Hashable {
+    let followId: Int
     let id: Int
     let nickname: String
     let username: String

--- a/CoreDisc/Responses/Notification/NotificationResponse.swift
+++ b/CoreDisc/Responses/Notification/NotificationResponse.swift
@@ -24,11 +24,11 @@ struct NotificationValues: Decodable, Identifiable, Hashable {
     let notificationId: Int
     let type: String
     let content: String
-    let targetId: Int
-    let senderId: Int
-    let senderUsername: String
-    let senderNickname: String
-    let profileImgDTO: NotificationProfileImgDTO
+    let targetId: Int?
+    let senderId: Int?
+    let senderUsername: String?
+    let senderNickname: String?
+    let profileImgDTO: NotificationProfileImgDTO?
     let isRead: Bool
     let createdAt: String
     let timeStamp: String

--- a/CoreDisc/Route/MyhomeRoute.swift
+++ b/CoreDisc/Route/MyhomeRoute.swift
@@ -1,0 +1,24 @@
+//
+//  MyhomeRoute.swift
+//  CoreDisc
+//
+//  Created by 김미주 on 8/17/25.
+//
+
+import Foundation
+
+enum MyhomeRoute: Hashable {
+    case home
+    case core
+    case edit
+    case post(postId: Int)
+    
+    case calendar
+    
+    case setting
+    case account
+    case block
+    case notification
+    
+    case user(userId: Int)
+}

--- a/CoreDisc/Route/MyhomeRoute.swift
+++ b/CoreDisc/Route/MyhomeRoute.swift
@@ -20,5 +20,5 @@ enum MyhomeRoute: Hashable {
     case block
     case notification
     
-    case user(userId: Int)
+    case user(userName: String)
 }

--- a/CoreDisc/Route/NavigationRouter.swift
+++ b/CoreDisc/Route/NavigationRouter.swift
@@ -1,0 +1,32 @@
+//
+//  NavigationRouter.swift
+//  CoreDisc
+//
+//  Created by 김미주 on 8/17/25.
+//
+
+import Foundation
+import SwiftUI
+import Observation
+
+@Observable
+final class NavigationRouter<Route: Hashable> {
+    var path = NavigationPath()
+    
+    // 추가
+    func push(_ route: Route) {
+        path.append(route)
+    }
+    
+    // 마지막 화면 제거
+    func pop() {
+        if !path.isEmpty {
+            path.removeLast()
+        }
+    }
+    
+    // 초기화
+    func reset() {
+        path = NavigationPath()
+    }
+}

--- a/CoreDisc/Route/OnboardingRoute.swift
+++ b/CoreDisc/Route/OnboardingRoute.swift
@@ -1,0 +1,15 @@
+//
+//  OnboardingRoute.swift
+//  CoreDisc
+//
+//  Created by 김미주 on 8/18/25.
+//
+
+import Foundation
+
+enum OnboardingRoute: Hashable {
+    case login
+    case signup
+    case findId
+    case findPw
+}

--- a/CoreDisc/Route/PostRoute.swift
+++ b/CoreDisc/Route/PostRoute.swift
@@ -12,6 +12,12 @@ enum PostRoute: Hashable {
     case search
     case notification
     case detail(postId: Int)
+    
+    // 댓글
     case user(userName: String)
     case myHome
+    
+    // 알림
+    case write
+    case questionMain
 }

--- a/CoreDisc/Route/PostRoute.swift
+++ b/CoreDisc/Route/PostRoute.swift
@@ -12,4 +12,6 @@ enum PostRoute: Hashable {
     case search
     case notification
     case detail(postId: Int)
+    case user(userName: String)
+    case myHome
 }

--- a/CoreDisc/Route/PostRoute.swift
+++ b/CoreDisc/Route/PostRoute.swift
@@ -1,0 +1,15 @@
+//
+//  PostRoute.swift
+//  CoreDisc
+//
+//  Created by 김미주 on 8/17/25.
+//
+
+import Foundation
+
+enum PostRoute: Hashable {
+    case home
+    case search
+    case notification
+    case detail(postId: Int)
+}

--- a/CoreDisc/Route/QuestionRoute.swift
+++ b/CoreDisc/Route/QuestionRoute.swift
@@ -11,13 +11,12 @@ enum QuestionRoute: Hashable {
     case main
     
     case write
-    case summary
+    case summary(questionId: Int?, selectedCategory: CategoryType, text: String)
     
     case basic
     
-    case popular
+    case trending
     
     case shareNow
     case shareList
-    case saveList
 }

--- a/CoreDisc/Route/QuestionRoute.swift
+++ b/CoreDisc/Route/QuestionRoute.swift
@@ -13,10 +13,10 @@ enum QuestionRoute: Hashable {
     case write
     case summary(questionId: Int?, selectedCategory: CategoryType, text: String)
     
-    case basic
+    case basic(selectedQuestionType: String, order: Int)
     
-    case trending
+    case trending(selectedQuestionType: String, order: Int)
     
-    case shareNow
-    case shareList
+    case shareNow(selectedQuestionType: String, order: Int)
+    case shareList(isSaveMode: Bool, selectedQuestionType: String, order: Int)
 }

--- a/CoreDisc/Route/QuestionRoute.swift
+++ b/CoreDisc/Route/QuestionRoute.swift
@@ -1,0 +1,23 @@
+//
+//  QuestionRoute.swift
+//  CoreDisc
+//
+//  Created by 김미주 on 8/17/25.
+//
+
+import Foundation
+
+enum QuestionRoute: Hashable {
+    case main
+    
+    case write
+    case summary
+    
+    case basic
+    
+    case popular
+    
+    case shareNow
+    case shareList
+    case saveList
+}

--- a/CoreDisc/Route/ReportRoute.swift
+++ b/CoreDisc/Route/ReportRoute.swift
@@ -9,7 +9,7 @@ import Foundation
 
 enum ReportRoute: Hashable {
     case museum
-    case cover
-    case report
-    case detail
+    case cover(discId: Int)
+    case detail(year: Int, month: Int)
+    case summary(SummaryYear: Int, SummaryMonth: Int)
 }

--- a/CoreDisc/Route/ReportRoute.swift
+++ b/CoreDisc/Route/ReportRoute.swift
@@ -1,0 +1,15 @@
+//
+//  ReportRoute.swift
+//  CoreDisc
+//
+//  Created by 김미주 on 8/17/25.
+//
+
+import Foundation
+
+enum ReportRoute: Hashable {
+    case museum
+    case cover
+    case report
+    case detail
+}

--- a/CoreDisc/Route/WriteRoute.swift
+++ b/CoreDisc/Route/WriteRoute.swift
@@ -1,0 +1,14 @@
+//
+//  WriteRoute.swift
+//  CoreDisc
+//
+//  Created by 김미주 on 8/17/25.
+//
+
+import Foundation
+
+enum WriteRoute: Hashable {
+    case answer
+    case select
+    case summary
+}

--- a/CoreDisc/ViewModels/MyHome/FollowSheetViewModel.swift
+++ b/CoreDisc/ViewModels/MyHome/FollowSheetViewModel.swift
@@ -46,6 +46,7 @@ class FollowSheetViewModel: ObservableObject {
         case .follower:
             return followerList.map {
                 FollowDisplayModel(
+                    followId: $0.followId,
                     id: $0.followerId,
                     nickname: $0.nickname,
                     username: $0.username,
@@ -57,6 +58,7 @@ class FollowSheetViewModel: ObservableObject {
         case .userFollower:
             return userFollowerList.map {
                 FollowDisplayModel(
+                    followId: $0.followId,
                     id: $0.followerId,
                     nickname: $0.nickname,
                     username: $0.username,
@@ -68,6 +70,7 @@ class FollowSheetViewModel: ObservableObject {
         case .following:
             return followingList.map {
                 FollowDisplayModel(
+                    followId: $0.followId,
                     id: $0.followingId,
                     nickname: $0.nickname,
                     username: $0.username,
@@ -79,6 +82,7 @@ class FollowSheetViewModel: ObservableObject {
         case .userFollowing:
             return userFollowingList.map {
                 FollowDisplayModel(
+                    followId: $0.followId,
                     id: $0.followingId,
                     nickname: $0.nickname,
                     username: $0.username,
@@ -90,6 +94,7 @@ class FollowSheetViewModel: ObservableObject {
         case .coreList:
             return coreList.map {
                 FollowDisplayModel(
+                    followId: $0.followId,
                     id: $0.followerId,
                     nickname: $0.nickname,
                     username: $0.username,
@@ -149,7 +154,7 @@ class FollowSheetViewModel: ObservableObject {
     // MARK: - Functions - API
     func fetchFollowers(
         cursorId: Int? = nil,
-        size: Int? = 20
+        size: Int? = 10
     ) {
         followProvider.request(.getFollowers(cursorId: cursorId, size: size)) { result in
             switch result {
@@ -186,7 +191,7 @@ class FollowSheetViewModel: ObservableObject {
     
     func fetchFollowings(
         cursorId: Int? = nil,
-        size: Int? = 20
+        size: Int? = 10
     ) {
         followProvider.request(.getFollowings(cursorId: cursorId, size: size)) { result in
             switch result {
@@ -224,7 +229,7 @@ class FollowSheetViewModel: ObservableObject {
     func fetchUserFollowers(
         targetUsername: String,
         cursorId: Int? = nil,
-        size: Int? = 20
+        size: Int? = 10
     ) {
         followProvider.request(.getFollowersTarget(
             targetUsername: targetUsername,
@@ -266,7 +271,7 @@ class FollowSheetViewModel: ObservableObject {
     func fetchUserFollowings(
         targetUsername: String,
         cursorId: Int? = nil,
-        size: Int? = 20
+        size: Int? = 10
     ) {
         followProvider.request(.getFollowingsTarget(
             targetUsername: targetUsername,
@@ -333,7 +338,7 @@ class FollowSheetViewModel: ObservableObject {
     
     func fetchCircleList(
         cursorId: Int? = nil,
-        size: Int? = 20
+        size: Int? = 10
     ) {
         circleProvier.request(.getCircle(cursorId: cursorId, size: size)) { result in
             switch result {

--- a/CoreDisc/ViewModels/MyHome/FollowSheetViewModel.swift
+++ b/CoreDisc/ViewModels/MyHome/FollowSheetViewModel.swift
@@ -50,7 +50,8 @@ class FollowSheetViewModel: ObservableObject {
                     nickname: $0.nickname,
                     username: $0.username,
                     profileImgUrl: $0.profileImgDTO?.imageUrl,
-                    isCore: $0.isCircle
+                    isCore: $0.isCircle,
+                    isMutual: $0.isMutual
                 )
             }
         case .userFollower:
@@ -60,7 +61,8 @@ class FollowSheetViewModel: ObservableObject {
                     nickname: $0.nickname,
                     username: $0.username,
                     profileImgUrl: $0.profileImgDTO?.imageUrl,
-                    isCore: false
+                    isCore: false,
+                    isMutual: nil
                 )
             }
         case .following:
@@ -70,7 +72,8 @@ class FollowSheetViewModel: ObservableObject {
                     nickname: $0.nickname,
                     username: $0.username,
                     profileImgUrl: $0.profileImgDTO?.imageUrl,
-                    isCore: false
+                    isCore: false,
+                    isMutual: nil
                 )
             }
         case .userFollowing:
@@ -80,7 +83,8 @@ class FollowSheetViewModel: ObservableObject {
                     nickname: $0.nickname,
                     username: $0.username,
                     profileImgUrl: $0.profileImgDTO?.imageUrl,
-                    isCore: false
+                    isCore: false,
+                    isMutual: nil
                 )
             }
         case .coreList:
@@ -90,7 +94,8 @@ class FollowSheetViewModel: ObservableObject {
                     nickname: $0.nickname,
                     username: $0.username,
                     profileImgUrl: $0.profileImgDTO?.imageUrl,
-                    isCore: false
+                    isCore: false,
+                    isMutual: $0.isMutual
                 )
             }
         }

--- a/CoreDisc/Views/Components/Cell.swift
+++ b/CoreDisc/Views/Components/Cell.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct Cell: View {
+    @Environment(NavigationRouter<MyhomeRoute>.self) private var router
+    
     var calendarDay: CalendarDayModel
     var isSelected: Bool
     let viewModel: CalendarContentsViewModel
@@ -19,7 +21,9 @@ struct Cell: View {
 
         Group {
             if let postId = dto?.postId {
-                NavigationLink(destination: PostDetailView(postId: postId)) {
+                Button(action: {
+                    router.push(.post(postId: postId))
+                }) {
                     cellBackground(isRecorded: isRecorded, isToday: isToday)
                 }
                 .buttonStyle(.plain)

--- a/CoreDisc/Views/Components/Modal/QuestionSelectModalView.swift
+++ b/CoreDisc/Views/Components/Modal/QuestionSelectModalView.swift
@@ -8,13 +8,15 @@
 import SwiftUI
 
 struct QuestionSelectModalView: View {
+    @Environment(NavigationRouter<QuestionRoute>.self) private var router
+    @EnvironmentObject var mainViewModel: QuestionMainViewModel
+    
     let isMonth: String
     @Binding var selectedQuestionId: Int?
     let order: Int
     let selectedQuestionType: SelectedQuestionType
     
     @ObservedObject var viewModel: QuestionBasicViewModel
-    @ObservedObject var mainViewModel: QuestionMainViewModel
     
     @Binding var showSelectModal: Bool
     

--- a/CoreDisc/Views/Container/MyhomeTabContainer.swift
+++ b/CoreDisc/Views/Container/MyhomeTabContainer.swift
@@ -1,0 +1,52 @@
+//
+//  MyhomeTabContainer.swift
+//  CoreDisc
+//
+//  Created by 김미주 on 8/17/25.
+//
+
+import SwiftUI
+
+struct MyhomeTabContainer: View {
+    @State private var router = NavigationRouter<MyhomeRoute>()
+    @State private var postRouter = NavigationRouter<PostRoute>()
+    
+    var body: some View {
+        NavigationStack(path: $router.path) {
+            MyHomeView()
+                .navigationDestination(for: MyhomeRoute.self) { route in
+                    switch route {
+                    case .home:
+                        MyHomeView()
+                    case .core:
+                        CoreQuestionsView()
+                    case .edit:
+                        EditProfileView()
+                    case .post(let postId):
+                        PostDetailView(postId: postId)
+                        
+                    case .calendar:
+                        CalendarView()
+                        
+                    case .setting:
+                        SettingView()
+                    case .account:
+                        AccountManageView()
+                    case .block:
+                        BlockListView()
+                    case .notification:
+                        NotificationSettingView()
+                        
+                    case .user(let userName):
+                        UserHomeView(userName: userName)
+                    }
+                }
+        }
+        .environment(router)
+        .environment(postRouter)
+    }
+}
+
+#Preview {
+    MyhomeTabContainer()
+}

--- a/CoreDisc/Views/Container/MyhomeTabContainer.swift
+++ b/CoreDisc/Views/Container/MyhomeTabContainer.swift
@@ -8,42 +8,35 @@
 import SwiftUI
 
 struct MyhomeTabContainer: View {
-    @State private var router = NavigationRouter<MyhomeRoute>()
-    @State private var postRouter = NavigationRouter<PostRoute>()
-    
     var body: some View {
-        NavigationStack(path: $router.path) {
-            MyHomeView()
-                .navigationDestination(for: MyhomeRoute.self) { route in
-                    switch route {
-                    case .home:
-                        MyHomeView()
-                    case .core:
-                        CoreQuestionsView()
-                    case .edit:
-                        EditProfileView()
-                    case .post(let postId):
-                        PostDetailView(postId: postId)
-                        
-                    case .calendar:
-                        CalendarView()
-                        
-                    case .setting:
-                        SettingView()
-                    case .account:
-                        AccountManageView()
-                    case .block:
-                        BlockListView()
-                    case .notification:
-                        NotificationSettingView()
-                        
-                    case .user(let userName):
-                        UserHomeView(userName: userName)
-                    }
+        MyHomeView()
+            .navigationDestination(for: MyhomeRoute.self) { route in
+                switch route {
+                case .home:
+                    MyHomeView()
+                case .core:
+                    CoreQuestionsView()
+                case .edit:
+                    EditProfileView()
+                case .post(let postId):
+                    PostDetailView(postId: postId)
+                    
+                case .calendar:
+                    CalendarView()
+                    
+                case .setting:
+                    SettingView()
+                case .account:
+                    AccountManageView()
+                case .block:
+                    BlockListView()
+                case .notification:
+                    NotificationSettingView()
+                    
+                case .user(let userName):
+                    UserHomeView(userName: userName)
                 }
-        }
-        .environment(router)
-        .environment(postRouter)
+            }
     }
 }
 

--- a/CoreDisc/Views/Container/OnboardingTabContainer.swift
+++ b/CoreDisc/Views/Container/OnboardingTabContainer.swift
@@ -1,0 +1,35 @@
+//
+//  OnboardingTabContainer.swift
+//  CoreDisc
+//
+//  Created by 김미주 on 8/18/25.
+//
+
+import SwiftUI
+
+struct OnboardingTabContainer: View {
+    @State private var router = NavigationRouter<OnboardingRoute>()
+    
+    var body: some View {
+        NavigationStack(path: $router.path) {
+            LoginView()
+                .navigationDestination(for: OnboardingRoute.self) { route in
+                    switch route {
+                    case .login:
+                        LoginView()
+                    case .signup:
+                        SignupView()
+                    case .findId:
+                        FindIdView()
+                    case .findPw:
+                        FindPwView()
+                    }
+                }
+        }
+        .environment(router)
+    }
+}
+
+#Preview {
+    OnboardingTabContainer()
+}

--- a/CoreDisc/Views/Container/PostTabContainer.swift
+++ b/CoreDisc/Views/Container/PostTabContainer.swift
@@ -1,0 +1,35 @@
+//
+//  PostTabContainer.swift
+//  CoreDisc
+//
+//  Created by 김미주 on 8/17/25.
+//
+
+import SwiftUI
+
+struct PostTabContainer: View {
+    @State private var router = NavigationRouter<PostRoute>()
+    
+    var body: some View {
+        NavigationStack(path: $router.path) {
+            PostMainView()
+                .navigationDestination(for: PostRoute.self) { route in
+                    switch route {
+                    case .home:
+                        PostMainView()
+                    case .search:
+                        SearchView()
+                    case .notification:
+                        NotificationView()
+                    case .detail(let postId):
+                        PostDetailView(postId: postId)
+                    }
+                }
+        }
+        .environment(router)
+    }
+}
+
+#Preview {
+    PostTabContainer()
+}

--- a/CoreDisc/Views/Container/PostTabContainer.swift
+++ b/CoreDisc/Views/Container/PostTabContainer.swift
@@ -23,6 +23,10 @@ struct PostTabContainer: View {
                         NotificationView()
                     case .detail(let postId):
                         PostDetailView(postId: postId)
+                    case .user(let userName):
+                        UserHomeView(userName: userName)
+                    case .myHome:
+                        MyHomeView()
                     }
                 }
         }

--- a/CoreDisc/Views/Container/PostTabContainer.swift
+++ b/CoreDisc/Views/Container/PostTabContainer.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct PostTabContainer: View {
     @State private var router = NavigationRouter<PostRoute>()
+    @State private var homeRouter = NavigationRouter<MyhomeRoute>()
     
     var body: some View {
         NavigationStack(path: $router.path) {
@@ -37,6 +38,7 @@ struct PostTabContainer: View {
                 }
         }
         .environment(router)
+        .environment(homeRouter)
     }
 }
 

--- a/CoreDisc/Views/Container/PostTabContainer.swift
+++ b/CoreDisc/Views/Container/PostTabContainer.swift
@@ -8,37 +8,30 @@
 import SwiftUI
 
 struct PostTabContainer: View {
-    @State private var router = NavigationRouter<PostRoute>()
-    @State private var homeRouter = NavigationRouter<MyhomeRoute>()
-    
     var body: some View {
-        NavigationStack(path: $router.path) {
-            PostMainView()
-                .navigationDestination(for: PostRoute.self) { route in
-                    switch route {
-                    case .home:
-                        PostMainView()
-                    case .search:
-                        SearchView()
-                    case .notification:
-                        NotificationView()
-                    case .detail(let postId):
-                        PostDetailView(postId: postId)
-                        
-                    case .user(let userName):
-                        UserHomeView(userName: userName)
-                    case .myHome:
-                        MyHomeView()
-                        
-                    case .write:
-                        PostWriteView()
-                    case .questionMain:
-                        QuestionMainView()
-                    }
+        PostMainView()
+            .navigationDestination(for: PostRoute.self) { route in
+                switch route {
+                case .home:
+                    PostMainView()
+                case .search:
+                    SearchView()
+                case .notification:
+                    NotificationView()
+                case .detail(let postId):
+                    PostDetailView(postId: postId)
+                    
+                case .user(let userName):
+                    UserHomeView(userName: userName)
+                case .myHome:
+                    MyHomeView()
+                    
+                case .write:
+                    PostWriteView()
+                case .questionMain:
+                    QuestionMainView()
                 }
-        }
-        .environment(router)
-        .environment(homeRouter)
+            }
     }
 }
 

--- a/CoreDisc/Views/Container/PostTabContainer.swift
+++ b/CoreDisc/Views/Container/PostTabContainer.swift
@@ -23,10 +23,16 @@ struct PostTabContainer: View {
                         NotificationView()
                     case .detail(let postId):
                         PostDetailView(postId: postId)
+                        
                     case .user(let userName):
                         UserHomeView(userName: userName)
                     case .myHome:
                         MyHomeView()
+                        
+                    case .write:
+                        PostWriteView()
+                    case .questionMain:
+                        QuestionMainView()
                     }
                 }
         }

--- a/CoreDisc/Views/Container/QuestionTabContainer.swift
+++ b/CoreDisc/Views/Container/QuestionTabContainer.swift
@@ -1,0 +1,53 @@
+//
+//  QuestionTabContainer.swift
+//  CoreDisc
+//
+//  Created by 김미주 on 8/17/25.
+//
+
+import SwiftUI
+
+struct QuestionTabContainer: View {
+    @State private var router = NavigationRouter<QuestionRoute>()
+    
+    var body: some View {
+        NavigationStack(path: $router.path) {
+            QuestionMainView()
+                .navigationDestination(for: QuestionRoute.self) { route in
+                    switch route {
+                    case .main:
+                        QuestionMainView()
+                        
+                    case .write:
+                        QuestionWriteView()
+                    case .summary(let questionId, let selectedCategory, let text):
+                        QuestionSummaryView(
+                            questionId: questionId,
+                            selectedCategory: selectedCategory,
+                            text: text
+                        )
+                        
+                    case .basic:
+//                        QuestionBasicView()
+                        EmptyView()
+                    
+                    case .trending:
+//                        QuestionTrendingView()
+                        EmptyView()
+
+                    case .shareNow:
+//                        QuestionShareNowView()
+                        EmptyView()
+                    case .shareList:
+//                        QuestionListView()
+                        EmptyView()
+                    }
+                }
+        }
+        .environment(router)
+    }
+}
+
+#Preview {
+    QuestionTabContainer()
+}

--- a/CoreDisc/Views/Container/QuestionTabContainer.swift
+++ b/CoreDisc/Views/Container/QuestionTabContainer.swift
@@ -8,54 +8,50 @@
 import SwiftUI
 
 struct QuestionTabContainer: View {
-    @State private var router = NavigationRouter<QuestionRoute>()
     @StateObject private var mainViewModel = QuestionMainViewModel()
     
     var body: some View {
-        NavigationStack(path: $router.path) {
-            QuestionMainView()
-                .navigationDestination(for: QuestionRoute.self) { route in
-                    switch route {
-                    case .main:
-                        QuestionMainView()
-                        
-                    case .write:
-                        QuestionWriteView()
-                    case .summary(let questionId, let selectedCategory, let text):
-                        QuestionSummaryView(
-                            questionId: questionId,
-                            selectedCategory: selectedCategory,
-                            text: text
-                        )
-                        
-                    case .basic(let selectedQuestionType, let order):
-                        QuestionBasicView(
-                            selectedQuestionType: selectedQuestionType,
-                            order: order
-                        )
+        QuestionMainView()
+            .navigationDestination(for: QuestionRoute.self) { route in
+                switch route {
+                case .main:
+                    QuestionMainView()
                     
-                    case .trending(let selectedQuestionType, let order):
-                        QuestionTrendingView(
-                            selectedQuestionType: selectedQuestionType,
-                            order: order
-                        )
-
-                    case .shareNow(let selectedQuestionType, let order):
-                        QuestionShareNowView(
-                            selectedQuestionType: selectedQuestionType,
-                            order: order
-                        )
-                    case .shareList(let isSaveMode, let selectedQuestionType, let order):
-                        QuestionListView(
-                            isSaveMode: isSaveMode,
-                            selectedQuestionType: selectedQuestionType,
-                            order: order
-                        )
-                    }
+                case .write:
+                    QuestionWriteView()
+                case .summary(let questionId, let selectedCategory, let text):
+                    QuestionSummaryView(
+                        questionId: questionId,
+                        selectedCategory: selectedCategory,
+                        text: text
+                    )
+                    
+                case .basic(let selectedQuestionType, let order):
+                    QuestionBasicView(
+                        selectedQuestionType: selectedQuestionType,
+                        order: order
+                    )
+                    
+                case .trending(let selectedQuestionType, let order):
+                    QuestionTrendingView(
+                        selectedQuestionType: selectedQuestionType,
+                        order: order
+                    )
+                    
+                case .shareNow(let selectedQuestionType, let order):
+                    QuestionShareNowView(
+                        selectedQuestionType: selectedQuestionType,
+                        order: order
+                    )
+                case .shareList(let isSaveMode, let selectedQuestionType, let order):
+                    QuestionListView(
+                        isSaveMode: isSaveMode,
+                        selectedQuestionType: selectedQuestionType,
+                        order: order
+                    )
                 }
-        }
-        .environment(router)
-        .environmentObject(mainViewModel)
+            }
+            .environmentObject(mainViewModel)
     }
 }
 

--- a/CoreDisc/Views/Container/QuestionTabContainer.swift
+++ b/CoreDisc/Views/Container/QuestionTabContainer.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct QuestionTabContainer: View {
     @State private var router = NavigationRouter<QuestionRoute>()
+    @StateObject private var mainViewModel = QuestionMainViewModel()
     
     var body: some View {
         NavigationStack(path: $router.path) {
@@ -27,24 +28,34 @@ struct QuestionTabContainer: View {
                             text: text
                         )
                         
-                    case .basic:
-//                        QuestionBasicView()
-                        EmptyView()
+                    case .basic(let selectedQuestionType, let order):
+                        QuestionBasicView(
+                            selectedQuestionType: selectedQuestionType,
+                            order: order
+                        )
                     
-                    case .trending:
-//                        QuestionTrendingView()
-                        EmptyView()
+                    case .trending(let selectedQuestionType, let order):
+                        QuestionTrendingView(
+                            selectedQuestionType: selectedQuestionType,
+                            order: order
+                        )
 
-                    case .shareNow:
-//                        QuestionShareNowView()
-                        EmptyView()
-                    case .shareList:
-//                        QuestionListView()
-                        EmptyView()
+                    case .shareNow(let selectedQuestionType, let order):
+                        QuestionShareNowView(
+                            selectedQuestionType: selectedQuestionType,
+                            order: order
+                        )
+                    case .shareList(let isSaveMode, let selectedQuestionType, let order):
+                        QuestionListView(
+                            isSaveMode: isSaveMode,
+                            selectedQuestionType: selectedQuestionType,
+                            order: order
+                        )
                     }
                 }
         }
         .environment(router)
+        .environmentObject(mainViewModel)
     }
 }
 

--- a/CoreDisc/Views/Container/ReportTabContainer.swift
+++ b/CoreDisc/Views/Container/ReportTabContainer.swift
@@ -1,0 +1,35 @@
+//
+//  ReportTabContainer.swift
+//  CoreDisc
+//
+//  Created by 김미주 on 8/17/25.
+//
+
+import SwiftUI
+
+struct ReportTabContainer: View {
+    @State private var router = NavigationRouter<ReportRoute>()
+    
+    var body: some View {
+        NavigationStack(path: $router.path) {
+            ReportMainView()
+                .navigationDestination(for: ReportRoute.self) { route in
+                    switch route {
+                    case .museum:
+                        ReportMainView()
+                    case .cover(let discId):
+                        ChangeCoverView(discId: discId)
+                    case .detail(let year, let month):
+                        ReportDetailView(year: year, month: month)
+                    case .summary(let SummaryYear, let SummaryMonth):
+                        ReportSummaryView(SummaryYear: SummaryYear, SummaryMonth: SummaryMonth)
+                    }
+                }
+        }
+        .environment(router)
+    }
+}
+
+#Preview {
+    ReportTabContainer()
+}

--- a/CoreDisc/Views/Container/ReportTabContainer.swift
+++ b/CoreDisc/Views/Container/ReportTabContainer.swift
@@ -8,25 +8,20 @@
 import SwiftUI
 
 struct ReportTabContainer: View {
-    @State private var router = NavigationRouter<ReportRoute>()
-    
     var body: some View {
-        NavigationStack(path: $router.path) {
-            ReportMainView()
-                .navigationDestination(for: ReportRoute.self) { route in
-                    switch route {
-                    case .museum:
-                        ReportMainView()
-                    case .cover(let discId):
-                        ChangeCoverView(discId: discId)
-                    case .detail(let year, let month):
-                        ReportDetailView(year: year, month: month)
-                    case .summary(let SummaryYear, let SummaryMonth):
-                        ReportSummaryView(SummaryYear: SummaryYear, SummaryMonth: SummaryMonth)
-                    }
+        ReportMainView()
+            .navigationDestination(for: ReportRoute.self) { route in
+                switch route {
+                case .museum:
+                    ReportMainView()
+                case .cover(let discId):
+                    ChangeCoverView(discId: discId)
+                case .detail(let year, let month):
+                    ReportDetailView(year: year, month: month)
+                case .summary(let SummaryYear, let SummaryMonth):
+                    ReportSummaryView(SummaryYear: SummaryYear, SummaryMonth: SummaryMonth)
                 }
-        }
-        .environment(router)
+            }
     }
 }
 

--- a/CoreDisc/Views/Container/WriteTabContainer.swift
+++ b/CoreDisc/Views/Container/WriteTabContainer.swift
@@ -1,0 +1,33 @@
+//
+//  WriteTabContainer.swift
+//  CoreDisc
+//
+//  Created by 김미주 on 8/17/25.
+//
+
+import SwiftUI
+
+struct WriteTabContainer: View {
+    @State private var router = NavigationRouter<WriteRoute>()
+    
+    var body: some View {
+        NavigationStack(path: $router.path) {
+            PostWriteView()
+                .navigationDestination(for: WriteRoute.self) { route in
+                    switch route {
+                    case .answer:
+                        PostWriteView()
+                    case .select:
+                        PostWriteDiaryView()
+                    case .summary:
+                        PostDiaryCheckView()
+                    }
+                }
+        }
+        .environment(router)
+    }
+}
+
+#Preview {
+    WriteTabContainer()
+}

--- a/CoreDisc/Views/Container/WriteTabContainer.swift
+++ b/CoreDisc/Views/Container/WriteTabContainer.swift
@@ -8,23 +8,18 @@
 import SwiftUI
 
 struct WriteTabContainer: View {
-    @State private var router = NavigationRouter<WriteRoute>()
-    
     var body: some View {
-        NavigationStack(path: $router.path) {
-            PostWriteView()
-                .navigationDestination(for: WriteRoute.self) { route in
-                    switch route {
-                    case .answer:
-                        PostWriteView()
-                    case .select:
-                        PostWriteDiaryView()
-                    case .summary:
-                        PostDiaryCheckView()
-                    }
+        PostWriteView()
+            .navigationDestination(for: WriteRoute.self) { route in
+                switch route {
+                case .answer:
+                    PostWriteView()
+                case .select:
+                    PostWriteDiaryView()
+                case .summary:
+                    PostDiaryCheckView()
                 }
-        }
-        .environment(router)
+            }
     }
 }
 

--- a/CoreDisc/Views/MyHome/AccountManageView.swift
+++ b/CoreDisc/Views/MyHome/AccountManageView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct AccountManageView: View {
+    @Environment(NavigationRouter<MyhomeRoute>.self) private var router
     
     @Environment(\.dismiss) var dismiss
     @StateObject private var viewModel = AccountManageViewModel()
@@ -19,51 +20,51 @@ struct AccountManageView: View {
     @State var WithdrawModal = false
     
     var body: some View {
-        NavigationStack{
-            ZStack {
-                Image(.imgShortBackground2)
-                    .resizable()
-                    .ignoresSafeArea()
-                    .onTapGesture { // 키보드 내리기 용도
-                        isFocused = false
-                    }
-                
-                VStack{
-                    TopMenuGroup
-                    Spacer().frame(height: 13)
-                    MainGroup
-                    Spacer()
+        ZStack {
+            Image(.imgShortBackground2)
+                .resizable()
+                .ignoresSafeArea()
+                .onTapGesture { // 키보드 내리기 용도
+                    isFocused = false
                 }
-                
-                if WithdrawModal {
-                    ModalView {
-                        VStack(spacing: 10) {
-                            Text("계정 탈퇴시 지금까지의 모든 데이터가 삭제됩니다.")
-                                .textStyle(.Button_s)
-                            
-                            Text("탈퇴하시겠습니까?")
-                                .textStyle(.Button_s)
-                        }
-                    } leftButton: {
-                        Button(action: {
-                            WithdrawModal.toggle()
-                        }) {
-                            Text("취소하기")
-                        }
-                    } rightButton: {
-                        Button(action: {
-                            WithdrawModal.toggle()
-                            viewModel.resign()
-                        }) {
-                            Text("탈퇴하기")
-                                .foregroundStyle(.red)
-                        }
+            
+            VStack{
+                TopMenuGroup
+                Spacer().frame(height: 13)
+                MainGroup
+                Spacer()
+            }
+            
+            if WithdrawModal {
+                ModalView {
+                    VStack(spacing: 10) {
+                        Text("계정 탈퇴시 지금까지의 모든 데이터가 삭제됩니다.")
+                            .textStyle(.Button_s)
+                        
+                        Text("탈퇴하시겠습니까?")
+                            .textStyle(.Button_s)
+                    }
+                } leftButton: {
+                    Button(action: {
+                        WithdrawModal.toggle()
+                    }) {
+                        Text("취소하기")
+                    }
+                } rightButton: {
+                    Button(action: {
+                        WithdrawModal.toggle()
+                        viewModel.resign()
+                    }) {
+                        Text("탈퇴하기")
+                            .foregroundStyle(.red)
                     }
                 }
             }
         }
         .navigationBarBackButtonHidden()
-        .navigationDestination(isPresented: $viewModel.resignSuccess) {LoginView()}
+        .fullScreenCover(isPresented: $viewModel.resignSuccess) {
+            LoginView()
+        }
     }
     
     private var TopMenuGroup: some View {

--- a/CoreDisc/Views/MyHome/AccountManageView.swift
+++ b/CoreDisc/Views/MyHome/AccountManageView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct AccountManageView: View {
     @Environment(NavigationRouter<MyhomeRoute>.self) private var router
     
-    @Environment(\.dismiss) var dismiss
     @StateObject private var viewModel = AccountManageViewModel()
     @FocusState private var isFocused: Bool
     
@@ -84,7 +83,7 @@ struct AccountManageView: View {
                 
                 HStack {
                     Button(action: {
-                        dismiss()
+                        router.pop()
                     }) {
                         Image(.iconBack)
                     }
@@ -232,7 +231,7 @@ struct AccountManageView: View {
             .disabled(viewModel.pwd.isEmpty || viewModel.newPwd.isEmpty || viewModel.rePwd.isEmpty)
             .onChange(of: viewModel.changeSuccess, {
                 if viewModel.changeSuccess {
-                    dismiss()
+                    router.pop()
                 }
             })
             

--- a/CoreDisc/Views/MyHome/BlockListView.swift
+++ b/CoreDisc/Views/MyHome/BlockListView.swift
@@ -113,7 +113,7 @@ struct BlockListView: View {
                             item: item,
                             blockedUserId: $blockedUserId,
                             showUnblockModal: $showUnblockModal
-                        )
+                        ) // TODO: API 커서
                     }
                 }
                 .padding(.top, 39)

--- a/CoreDisc/Views/MyHome/BlockListView.swift
+++ b/CoreDisc/Views/MyHome/BlockListView.swift
@@ -11,7 +11,6 @@ import Kingfisher
 struct BlockListView: View {
     @Environment(NavigationRouter<MyhomeRoute>.self) private var router
     
-    @Environment(\.dismiss) var dismiss
     @StateObject var userViewModel = UserHomeViewModel()
     @StateObject private var viewModel = BlockListViewModel()
     
@@ -87,7 +86,7 @@ struct BlockListView: View {
                 
                 HStack {
                     Button(action: {
-                        dismiss()
+                        router.pop()
                     }) {
                         Image(.iconBack)
                     }

--- a/CoreDisc/Views/MyHome/BlockListView.swift
+++ b/CoreDisc/Views/MyHome/BlockListView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 import Kingfisher
 
 struct BlockListView: View {
+    @Environment(NavigationRouter<MyhomeRoute>.self) private var router
+    
     @Environment(\.dismiss) var dismiss
     @StateObject var userViewModel = UserHomeViewModel()
     @StateObject private var viewModel = BlockListViewModel()

--- a/CoreDisc/Views/MyHome/CalendarView.swift
+++ b/CoreDisc/Views/MyHome/CalendarView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct CalendarView: View {
+    @Environment(NavigationRouter<MyhomeRoute>.self) private var router
+    
     @StateObject var viewModel: CalendarContentsViewModel
     @Environment(\.dismiss) var dismiss
     

--- a/CoreDisc/Views/MyHome/CalendarView.swift
+++ b/CoreDisc/Views/MyHome/CalendarView.swift
@@ -11,7 +11,6 @@ struct CalendarView: View {
     @Environment(NavigationRouter<MyhomeRoute>.self) private var router
     
     @StateObject var viewModel: CalendarContentsViewModel
-    @Environment(\.dismiss) var dismiss
     
     @State private var dragOffset: CGFloat = 0
     private let swipeThreshold: CGFloat = 50
@@ -87,7 +86,7 @@ struct CalendarView: View {
                 Spacer().frame(width: 3)
                 
                 Button(action: {
-                    dismiss()
+                    router.pop()
                 }) {
                     Image(.iconBack)
                         .resizable()

--- a/CoreDisc/Views/MyHome/CoreQuestionsView.swift
+++ b/CoreDisc/Views/MyHome/CoreQuestionsView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct CoreQuestionsView: View {
+    @Environment(NavigationRouter<MyhomeRoute>.self) private var router
+    
     @Environment(\.dismiss) var dismiss
     
     @StateObject private var viewModel = CoreQuestionsViewModel()

--- a/CoreDisc/Views/MyHome/CoreQuestionsView.swift
+++ b/CoreDisc/Views/MyHome/CoreQuestionsView.swift
@@ -10,8 +10,6 @@ import SwiftUI
 struct CoreQuestionsView: View {
     @Environment(NavigationRouter<MyhomeRoute>.self) private var router
     
-    @Environment(\.dismiss) var dismiss
-    
     @StateObject private var viewModel = CoreQuestionsViewModel()
     
     var body: some View {
@@ -58,7 +56,7 @@ struct CoreQuestionsView: View {
                     
                 
                 Button(action: {
-                    dismiss()
+                    router.pop()
                 }) {
                     Image(.iconBack)
                 }

--- a/CoreDisc/Views/MyHome/CoreQuestionsView.swift
+++ b/CoreDisc/Views/MyHome/CoreQuestionsView.swift
@@ -199,6 +199,7 @@ struct CoreQuestionList: View {
                                 .foregroundStyle(item.isShared ? .key : .gray600)
                         }
                     }
+                    .containerRelativeFrame(.vertical, count: 5, spacing: 8) // 5개씩 보이게
                 }
             }
         }

--- a/CoreDisc/Views/MyHome/EditProfileView.swift
+++ b/CoreDisc/Views/MyHome/EditProfileView.swift
@@ -10,6 +10,8 @@ import PhotosUI
 import Kingfisher
 
 struct EditProfileView: View {
+    @Environment(NavigationRouter<MyhomeRoute>.self) private var router
+    
     @StateObject private var viewModel = MyHomeViewModel()
 
     @Environment(\.dismiss) var dismiss
@@ -40,6 +42,9 @@ struct EditProfileView: View {
                 
                 Spacer()
             }
+        }
+        .fullScreenCover(isPresented: $viewModel.logoutSuccess) {
+            LoginView()
         }
         .task {
             viewModel.fetchMyHome()
@@ -86,7 +91,6 @@ struct EditProfileView: View {
                             dismiss()
                         }
                     }
-                    .navigationDestination(isPresented: $viewModel.logoutSuccess) {LoginView()}
                 }
                 .padding(.leading, 17)
                 .padding(.trailing, 22)

--- a/CoreDisc/Views/MyHome/EditProfileView.swift
+++ b/CoreDisc/Views/MyHome/EditProfileView.swift
@@ -14,7 +14,6 @@ struct EditProfileView: View {
     
     @StateObject private var viewModel = MyHomeViewModel()
 
-    @Environment(\.dismiss) var dismiss
     @FocusState private var isFocused: Bool
     
     @State private var showEditButton: Bool = false
@@ -71,7 +70,7 @@ struct EditProfileView: View {
                 
                 HStack {
                     Button(action: {
-                        dismiss()
+                        router.pop()
                     }) {
                         Image(.iconBack)
                     }
@@ -88,7 +87,7 @@ struct EditProfileView: View {
                     }
                     .onChange(of: viewModel.changeSuccess) { oldValue, newValue in
                         if newValue {
-                            dismiss()
+                            router.pop()
                         }
                     }
                 }

--- a/CoreDisc/Views/MyHome/FollowSheetView.swift
+++ b/CoreDisc/Views/MyHome/FollowSheetView.swift
@@ -14,6 +14,8 @@ struct FollowSheetView: View {
     
     @State private var currentFollowType: FollowType = .follower
     
+    @Binding var showMutualModal: Bool
+    
     var followType: FollowType
     var targetUsrname: String
     
@@ -113,6 +115,7 @@ struct FollowSheetView: View {
                         FollowListItem(
                             item: item,
                             followType: currentFollowType,
+                            showMutualModal: $showMutualModal,
                             isCoreList: item.isCore,
                             viewModel: viewModel
                         )
@@ -137,6 +140,7 @@ struct FollowSheetView: View {
 struct FollowListItem: View {
     let item: FollowDisplayModel
     var followType: FollowType
+    @Binding var showMutualModal: Bool
     
     @State var isCoreList: Bool
     @State var showLabel: Bool = false
@@ -173,16 +177,20 @@ struct FollowListItem: View {
             if followType == .follower || followType == .coreList {
                 VStack(spacing: 4) {
                     Button(action: {
-                        viewModel.fetchCircle(targetId: item.id, isCircle: !isCoreList) {
-                            isCoreList.toggle()
-                            showLabel = true
-                            
-                            // 시간 지나면 자동으로 label 없애기
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                                withAnimation {
-                                    showLabel = false
+                        if item.isMutual == true {
+                            viewModel.fetchCircle(targetId: item.id, isCircle: !isCoreList) {
+                                isCoreList.toggle()
+                                showLabel = true
+                                
+                                // 시간 지나면 자동으로 label 없애기
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                                    withAnimation {
+                                        showLabel = false
+                                    }
                                 }
                             }
+                        } else {
+                            showMutualModal = true
                         }
                     }) {
                         Image(.iconCore)
@@ -246,6 +254,6 @@ struct CorelistToggle: View {
     }
 }
 
-#Preview {
-    FollowSheetView(showSheet: .constant(true), followType: .following, targetUsrname: "")
-}
+//#Preview {
+//    FollowSheetView(showSheet: .constant(true), followType: .following, targetUsrname: "")
+//}

--- a/CoreDisc/Views/MyHome/FollowSheetView.swift
+++ b/CoreDisc/Views/MyHome/FollowSheetView.swift
@@ -30,7 +30,7 @@ struct FollowSheetView: View {
                 
                 SecondGroup
                 
-                FollowerList
+                FollowList
                 
                 Spacer()
             }
@@ -106,7 +106,7 @@ struct FollowSheetView: View {
     }
     
     // 리스트
-    private var FollowerList: some View {
+    private var FollowList: some View {
         ScrollView {
             LazyVStack(spacing: 16) {
                 let list = viewModel.getDisplayList(for: currentFollowType)
@@ -122,7 +122,7 @@ struct FollowSheetView: View {
                             .task {
                                 if item.id == list.last?.id,
                                    viewModel.hasNextPage(for: currentFollowType) {
-                                    viewModel.fetchMore(for: currentFollowType, cursorId: item.id)
+                                    viewModel.fetchMore(for: currentFollowType, cursorId: item.followId)
                                 }
                             }
                     }

--- a/CoreDisc/Views/MyHome/MyHomeView.swift
+++ b/CoreDisc/Views/MyHome/MyHomeView.swift
@@ -14,6 +14,8 @@ struct MyHomeView: View {
     @State var showFollowerSheet: Bool = false
     @State var showFollowingSheet: Bool = false
     
+    @State var showMutualModal: Bool = false
+    
     var body: some View {
         NavigationStack {
             ZStack {
@@ -44,6 +46,10 @@ struct MyHomeView: View {
                 }
                 
                 sheetView
+                
+                if showMutualModal {
+                    BackModalView(showModal: $showMutualModal, content: "Core List는 서로 팔로우 중일 때만\n설정할 수 있어요.")
+                }
             }
             .task {
                 viewModel.fetchMyHome()
@@ -231,15 +237,13 @@ struct MyHomeView: View {
     @ViewBuilder
     private var sheetView: some View {
         if showFollowerSheet {
-            FollowSheetView(showSheet: $showFollowerSheet, followType: .follower, targetUsrname: "")
+            FollowSheetView(showSheet: $showFollowerSheet, showMutualModal: $showMutualModal, followType: .follower, targetUsrname: "")
                 .transition(.move(edge: .bottom))
-                .zIndex(1)
         }
         
         if showFollowingSheet {
-            FollowSheetView(showSheet: $showFollowingSheet, followType: .following, targetUsrname: "")
+            FollowSheetView(showSheet: $showFollowingSheet, showMutualModal: .constant(false), followType: .following, targetUsrname: "")
                 .transition(.move(edge: .bottom))
-                .zIndex(1)
         }
     }
 }

--- a/CoreDisc/Views/MyHome/MyHomeView.swift
+++ b/CoreDisc/Views/MyHome/MyHomeView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 import Kingfisher
 
 struct MyHomeView: View {
+    @Environment(NavigationRouter<MyhomeRoute>.self) private var router
+    
     @StateObject private var viewModel = MyHomeViewModel()
     
     @State var showFollowerSheet: Bool = false
@@ -69,12 +71,16 @@ struct MyHomeView: View {
             Spacer()
             
             
-            NavigationLink(destination: CalendarView()) {
+            Button(action: {
+                router.push(.calendar)
+            }) {
                 Image(.iconCalendar)
                     .foregroundStyle(.white)
             }
             
-            NavigationLink(destination: SettingView()) {
+            Button(action: {
+                router.push(.setting)
+            }) {
                 Image(.iconSetting)
                     .foregroundStyle(.white)
             }
@@ -161,7 +167,9 @@ struct MyHomeView: View {
     // 버튼
     private var ButtonGroup: some View {
         VStack(spacing: 12) {
-            NavigationLink(destination: CoreQuestionsView()) {
+            Button(action: {
+                router.push(.core)
+            }) {
                 ZStack {
                     RoundedRectangle(cornerRadius: 12)
                         .fill(.key)
@@ -175,7 +183,9 @@ struct MyHomeView: View {
             }
             .buttonStyle(.plain)
             
-            NavigationLink(destination: EditProfileView()) {
+            Button(action: {
+                router.push(.edit)
+            }) {
                 ZStack {
                     RoundedRectangle(cornerRadius: 12)
                         .fill(.gray400)
@@ -197,7 +207,9 @@ struct MyHomeView: View {
         
         return LazyVGrid(columns: columns, spacing: 12) {
             ForEach(viewModel.postList, id: \.postId) { post in
-                NavigationLink(destination: PostDetailView(postId: post.postId)) {
+                Button(action: {
+                    router.push(.post(postId: post.postId))
+                }) {
                     if let url = URL(string: post.postImageThumbnailDTO?.thumbnailUrl ?? ""),
                        !url.absoluteString.isEmpty { // 이미지
                         KFImage(url)

--- a/CoreDisc/Views/MyHome/MyHomeView.swift
+++ b/CoreDisc/Views/MyHome/MyHomeView.swift
@@ -17,48 +17,46 @@ struct MyHomeView: View {
     @State var showMutualModal: Bool = false
     
     var body: some View {
-        NavigationStack {
-            ZStack {
-                Image(.imgShortBackground2)
-                    .resizable()
-                    .ignoresSafeArea()
+        ZStack {
+            Image(.imgShortBackground2)
+                .resizable()
+                .ignoresSafeArea()
+            
+            VStack(spacing: 0) {
+                Spacer().frame(height: 3)
                 
-                VStack(spacing: 0) {
-                    Spacer().frame(height: 3)
+                TopMenuGroup
+                
+                ScrollView {
+                    ProfileGroup
                     
-                    TopMenuGroup
+                    Spacer().frame(height: 14)
                     
-                    ScrollView {
-                        ProfileGroup
-                        
-                        Spacer().frame(height: 14)
-                        
-                        CountGroup
-                        
-                        Spacer().frame(height: 16)
-                        
-                        ButtonGroup
-                        
-                        Spacer().frame(height: 31)
-                        
-                        PostGroup
-                    }
-                }
-                
-                sheetView
-                
-                if showMutualModal {
-                    BackModalView(showModal: $showMutualModal, content: "Core List는 서로 팔로우 중일 때만\n설정할 수 있어요.")
+                    CountGroup
+                    
+                    Spacer().frame(height: 16)
+                    
+                    ButtonGroup
+                    
+                    Spacer().frame(height: 31)
+                    
+                    PostGroup
                 }
             }
-            .task {
-                viewModel.fetchMyHome()
-                viewModel.fetchMyPosts()
+            
+            sheetView
+            
+            if showMutualModal {
+                BackModalView(showModal: $showMutualModal, content: "Core List는 서로 팔로우 중일 때만\n설정할 수 있어요.")
             }
-            .animation(.easeInOut(duration: 0.3), value: showFollowerSheet)
-            .animation(.easeInOut(duration: 0.3), value: showFollowingSheet)
-            .navigationBarBackButtonHidden()
         }
+        .task {
+            viewModel.fetchMyHome()
+            viewModel.fetchMyPosts()
+        }
+        .animation(.easeInOut(duration: 0.3), value: showFollowerSheet)
+        .animation(.easeInOut(duration: 0.3), value: showFollowingSheet)
+        .navigationBarBackButtonHidden()
     }
     
     // 상단 메뉴
@@ -196,7 +194,7 @@ struct MyHomeView: View {
     // 게시글
     private var PostGroup: some View {
         let columns = Array(repeating: GridItem(.flexible()), count: 3)
-
+        
         return LazyVGrid(columns: columns, spacing: 12) {
             ForEach(viewModel.postList, id: \.postId) { post in
                 NavigationLink(destination: PostDetailView(postId: post.postId)) {

--- a/CoreDisc/Views/MyHome/SettingView.swift
+++ b/CoreDisc/Views/MyHome/SettingView.swift
@@ -8,53 +8,52 @@
 import SwiftUI
 
 struct SettingView: View {
+    @Environment(NavigationRouter<MyhomeRoute>.self) private var router
+    
     @Environment(\.dismiss) var dismiss
     @State var LogoutModal = false
     @StateObject private var viewModel = AccountManageViewModel()
     
     var body: some View {
-        NavigationStack{
-            ZStack {
-                Image(.imgShortBackground2)
-                    .resizable()
-                    .ignoresSafeArea()
+        ZStack {
+            Image(.imgShortBackground2)
+                .resizable()
+                .ignoresSafeArea()
+            
+            VStack(spacing: 0) {
+                Spacer().frame(height: 3)
                 
-                VStack(spacing: 0) {
-                    Spacer().frame(height: 3)
-                    
-                    TopMenuGroup
-                    
-                    Spacer().frame(height: 34)
-                    
-                    ButtonGroup
-                    
-                    Spacer()
-                }
-                if LogoutModal {
-                    ModalView {
-                        VStack {
-                            Text("로그아웃 하시겠습니까?")
-                                .textStyle(.Button_s)
-                        }
-                    } leftButton: {
-                        Button(action: {
-                            LogoutModal.toggle()
-                        }) {
-                            Text("돌아가기")
-                        }
-                    } rightButton: {
-                        Button(action: {
-                            LogoutModal.toggle()
-                            viewModel.logout()
-                        }) {
-                            Text("로그아웃")
-                                .foregroundStyle(.red)
-                        }
+                TopMenuGroup
+                
+                Spacer().frame(height: 34)
+                
+                ButtonGroup
+                
+                Spacer()
+            }
+            if LogoutModal {
+                ModalView {
+                    VStack {
+                        Text("로그아웃 하시겠습니까?")
+                            .textStyle(.Button_s)
+                    }
+                } leftButton: {
+                    Button(action: {
+                        LogoutModal.toggle()
+                    }) {
+                        Text("돌아가기")
+                    }
+                } rightButton: {
+                    Button(action: {
+                        LogoutModal.toggle()
+                        viewModel.logout()
+                    }) {
+                        Text("로그아웃")
+                            .foregroundStyle(.red)
                     }
                 }
             }
         }
-        .toolbarVisibility(.hidden, for: .navigationBar)
         .navigationBarBackButtonHidden()
         .fullScreenCover(isPresented: $viewModel.logoutSuccess) {LoginView()}
     }
@@ -92,9 +91,9 @@ struct SettingView: View {
     // 버튼
     private var ButtonGroup: some View {
         VStack(spacing: 18) {
-            SettingButton(title: "계정 관리", destination: { AnyView(AccountManageView()) })
-            SettingButton(title: "차단 유저 목록", destination: { AnyView(BlockListView()) })
-            SettingButton(title: "알림 설정", destination: { AnyView(NotificationSettingView()) })
+            SettingButton(title: "계정 관리", destination: .account)
+            SettingButton(title: "차단 유저 목록", destination: .block)
+            SettingButton(title: "알림 설정", destination: .notification)
             SettingButton(title: "로그아웃", onClick: { LogoutModal = true })
         }
     }
@@ -102,13 +101,17 @@ struct SettingView: View {
 
 // 설정 페이지 버튼
 struct SettingButton: View {
+    @Environment(NavigationRouter<MyhomeRoute>.self) private var router
+    
     var title: String
-    var destination: (() -> AnyView)?
+    var destination: MyhomeRoute?
     var onClick: (() -> Void)?
     
     var body: some View {
         if let destination = destination {
-            NavigationLink(destination: destination()) {
+            Button(action: {
+                router.push(destination)
+            }) {
                 buttonContent
             }
         } else {

--- a/CoreDisc/Views/MyHome/SettingView.swift
+++ b/CoreDisc/Views/MyHome/SettingView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct SettingView: View {
     @Environment(NavigationRouter<MyhomeRoute>.self) private var router
     
-    @Environment(\.dismiss) var dismiss
     @State var LogoutModal = false
     @StateObject private var viewModel = AccountManageViewModel()
     
@@ -76,7 +75,7 @@ struct SettingView: View {
                 
                 HStack {
                     Button(action: {
-                        dismiss()
+                        router.pop()
                     }) {
                         Image(.iconBack)
                     }

--- a/CoreDisc/Views/MyHome/UserHomeView.swift
+++ b/CoreDisc/Views/MyHome/UserHomeView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 import Kingfisher
 
 struct UserHomeView: View {
+    @Environment(NavigationRouter<MyhomeRoute>.self) private var router
+    
     @StateObject var viewModel = UserHomeViewModel()
     
     @Environment(\.dismiss) var dismiss
@@ -286,7 +288,9 @@ struct UserHomeView: View {
         
         return LazyVGrid(columns: columns, spacing: 12) {
             ForEach(viewModel.postList, id: \.postId) { post in
-                NavigationLink(destination: PostDetailView(postId: post.postId)) {
+                Button(action: {
+                    router.push(.post(postId: post.postId))
+                }) {
                     if let url = URL(string: post.postImageThumbnailDTO?.thumbnailUrl ?? ""),
                        !url.absoluteString.isEmpty { // 이미지
                         KFImage(url)

--- a/CoreDisc/Views/MyHome/UserHomeView.swift
+++ b/CoreDisc/Views/MyHome/UserHomeView.swift
@@ -324,13 +324,13 @@ struct UserHomeView: View {
     @ViewBuilder
     private var sheetView: some View {
         if showFollowerSheet {
-            FollowSheetView(showSheet: $showFollowerSheet, followType: .userFollower, targetUsrname: userName)
+            FollowSheetView(showSheet: $showFollowerSheet, showMutualModal: .constant(false), followType: .userFollower, targetUsrname: userName)
                 .transition(.move(edge: .bottom))
                 .zIndex(1)
         }
         
         if showFollowingSheet {
-            FollowSheetView(showSheet: $showFollowingSheet, followType: .userFollowing, targetUsrname: userName)
+            FollowSheetView(showSheet: $showFollowingSheet, showMutualModal: .constant(false), followType: .userFollowing, targetUsrname: userName)
                 .transition(.move(edge: .bottom))
                 .zIndex(1)
         }

--- a/CoreDisc/Views/MyHome/UserHomeView.swift
+++ b/CoreDisc/Views/MyHome/UserHomeView.swift
@@ -13,8 +13,6 @@ struct UserHomeView: View {
     
     @StateObject var viewModel = UserHomeViewModel()
     
-    @Environment(\.dismiss) var dismiss
-    
     @State var showBlockButton: Bool = false
     @State var showBlockModal: Bool = false
     @State var showUnblockModal: Bool = false
@@ -139,7 +137,7 @@ struct UserHomeView: View {
             
             HStack(alignment: .top) {
                 Button(action: {
-                    dismiss()
+                    router.pop()
                 }) {
                     Image(.iconBack)
                 }

--- a/CoreDisc/Views/Notification/NotificationSettingView.swift
+++ b/CoreDisc/Views/Notification/NotificationSettingView.swift
@@ -11,7 +11,6 @@ struct NotificationSettingView: View {
     @Environment(NavigationRouter<MyhomeRoute>.self) private var router
     
     @StateObject var viewModel = NotificationSettingViewModel()
-    @Environment(\.dismiss) var dismiss
     
     // 시간
     @State var showSheet: Bool = false
@@ -70,7 +69,7 @@ struct NotificationSettingView: View {
                 
                 HStack {
                     Button(action: {
-                        dismiss()
+                        router.pop()
                     }) {
                         Image(.iconBack)
                     }

--- a/CoreDisc/Views/Notification/NotificationSettingView.swift
+++ b/CoreDisc/Views/Notification/NotificationSettingView.swift
@@ -8,14 +8,13 @@
 import SwiftUI
 
 struct NotificationSettingView: View {
+    @Environment(NavigationRouter<MyhomeRoute>.self) private var router
+    
     @StateObject var viewModel = NotificationSettingViewModel()
     @Environment(\.dismiss) var dismiss
     
     // 시간
     @State var showSheet: Bool = false
-    
-    // TODO: 토글에 따라 시간 버튼 활성화/비활성화 처리
-    // TODO: 바텀시트 배경 비활성화 처리
 
     var body: some View {
         ZStack {
@@ -46,7 +45,7 @@ struct NotificationSettingView: View {
             }
         }
         .animation(.easeInOut(duration: 0.3), value: showSheet)
-        .toolbarVisibility(.hidden, for: .navigationBar)
+        .navigationBarBackButtonHidden()
         .task {
             viewModel.fetchReminderState()
         }

--- a/CoreDisc/Views/Notification/NotificationView.swift
+++ b/CoreDisc/Views/Notification/NotificationView.swift
@@ -38,12 +38,12 @@ struct NotificationView: View {
         .navigationDestination(item: $selectedItem) { item in
             switch item.type {
             case "FOLLOW":
-                UserHomeView(userName: item.senderUsername)
+                UserHomeView(userName: item.senderUsername ?? "")
             case "SHARED_SAVED":
                 EmptyView()
 //                QuestionShareNowView()
             case "COMMEND", "COMMENT_REPLY", "LIKE":
-                PostDetailView(postId: item.targetId)
+                PostDetailView(postId: item.targetId ?? 0)
             case "TEMP_POSTS":
                 PostWriteView()
             case "DAILY_REMINDER", "UNANSWERED_REMINDER":
@@ -146,7 +146,7 @@ struct NotificationListItem: View {
                     .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 2)
                 
                 HStack(spacing: 18) {
-                    if let imageUrl = item.profileImgDTO.imageUrl,
+                    if let imageUrl = item.profileImgDTO?.imageUrl,
                        let url = URL(string: imageUrl) {
                         KFImage(url)
                             .resizable()

--- a/CoreDisc/Views/Notification/NotificationView.swift
+++ b/CoreDisc/Views/Notification/NotificationView.swift
@@ -9,12 +9,10 @@ import SwiftUI
 import Kingfisher
 
 struct NotificationView: View {
-    @Environment(\.dismiss) private var dismiss
+    @Environment(NavigationRouter<PostRoute>.self) private var router
     
     @StateObject private var viewModel = NotificationViewModel()
     @StateObject var mainViewModel = QuestionMainViewModel()
-    
-    @State private var selectedItem: NotificationValues?
     
     var body: some View {
         ZStack{
@@ -35,25 +33,6 @@ struct NotificationView: View {
         .refreshable { // 당겨서 새로고침
             viewModel.refresh()
         }
-        .navigationDestination(item: $selectedItem) { item in
-            switch item.type {
-            case "FOLLOW":
-                UserHomeView(userName: item.senderUsername ?? "")
-            case "SHARED_SAVED":
-                EmptyView()
-//                QuestionShareNowView()
-            case "COMMEND", "COMMENT_REPLY", "LIKE":
-                PostDetailView(postId: item.targetId ?? 0)
-            case "TEMP_POSTS":
-                PostWriteView()
-            case "DAILY_REMINDER", "UNANSWERED_REMINDER":
-                QuestionMainView()
-            case "DAILY_REMINDER_ANSWER", "UNANSWERED_REMINDER_ANSWER":
-                PostWriteView()
-            default:
-                EmptyView()
-            }
-        }
     }
     
     // 상단 메뉴
@@ -66,7 +45,7 @@ struct NotificationView: View {
             
             HStack {
                 Button(action: {
-                    dismiss()
+                    router.pop()
                 }) {
                     Image(.iconBack)
                 }
@@ -75,7 +54,7 @@ struct NotificationView: View {
             }
             .padding(.leading, 17)
         }
-
+        
     }
     
     // 알림 리스트
@@ -86,11 +65,13 @@ struct NotificationView: View {
                     NotificationDate(date: group.date)
                     
                     ForEach(group.values, id: \.notificationId) { item in
-                        NotificationListItem(viewModel: viewModel, item: item) {
-                            selectedItem = item
+                        Button(action: {
                             if !item.isRead {
                                 viewModel.fetchRead(notificationId: item.notificationId)
                             }
+                            route(from: item)
+                        }) {
+                            NotificationListItem(item: item)
                         }
                         .task {
                             viewModel.loadNextPageIfNeeded(currentItem: item)
@@ -101,6 +82,32 @@ struct NotificationView: View {
             .padding(.bottom, 75)
         }
         .scrollIndicators(.hidden)
+    }
+    
+    private func route(from item: NotificationValues) {
+        switch item.type {
+        case "FOLLOW":
+            router.push(.user(userName: item.senderUsername ?? ""))
+            
+        case "SHARED_SAVED":
+            // TODO: 화면 전환
+            break
+            
+        case "COMMEND", "COMMENT_REPLY", "LIKE":
+            router.push(.detail(postId: item.targetId ?? 0))
+            
+        case "TEMP_POSTS":
+            router.push(.write)
+            
+        case "DAILY_REMINDER", "UNANSWERED_REMINDER":
+            router.push(.questionMain)
+            
+        case "DAILY_REMINDER_ANSWER", "UNANSWERED_REMINDER_ANSWER":
+            router.push(.write)
+            
+        default:
+            break
+        }
     }
 }
 
@@ -128,51 +135,41 @@ struct NotificationDate: View {
 
 // 알림 리스트 아이템
 struct NotificationListItem: View {
-    @ObservedObject var viewModel: NotificationViewModel
-    
     var item: NotificationValues
-    var onTap: () -> Void
     
     var body: some View {
-        Button(action: {
-            if !item.isRead {
-                viewModel.fetchRead(notificationId: item.notificationId)
-            }
-            onTap()
-        }) {
-            ZStack(alignment: .leading) {
-                Rectangle()
-                    .fill(item.isRead ? .gray200 : .highlight)
-                    .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 2)
-                
-                HStack(spacing: 18) {
-                    if let imageUrl = item.profileImgDTO?.imageUrl,
-                       let url = URL(string: imageUrl) {
-                        KFImage(url)
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: 36, height: 36)
-                            .clipShape(Circle())
-                    } else {
-                        Circle()
-                            .fill(.gray400)
-                            .frame(width: 36, height: 36)
-                    }
-                    
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(item.content)
-                            .textStyle(.A_Main)
-                            .foregroundStyle(.black000)
-                        Text(item.timeStamp)
-                            .textStyle(.Small_Text_10)
-                            .foregroundStyle(.black000)
-                    }
+        ZStack(alignment: .leading) {
+            Rectangle()
+                .fill(item.isRead ? .gray200 : .highlight)
+                .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 2)
+            
+            HStack(spacing: 18) {
+                if let imageUrl = item.profileImgDTO?.imageUrl,
+                   let url = URL(string: imageUrl) {
+                    KFImage(url)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 36, height: 36)
+                        .clipShape(Circle())
+                } else {
+                    Circle()
+                        .fill(.gray400)
+                        .frame(width: 36, height: 36)
                 }
-                .padding(.leading, 28)
+                
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(item.content)
+                        .textStyle(.A_Main)
+                        .foregroundStyle(.black000)
+                    Text(item.timeStamp)
+                        .textStyle(.Small_Text_10)
+                        .foregroundStyle(.black000)
+                }
             }
-            .frame(height: 63)
-            .frame(maxWidth: .infinity)
+            .padding(.leading, 28)
         }
+        .frame(height: 63)
+        .frame(maxWidth: .infinity)
     }
 }
 

--- a/CoreDisc/Views/Onboarding/FindIdView.swift
+++ b/CoreDisc/Views/Onboarding/FindIdView.swift
@@ -8,43 +8,42 @@
 import SwiftUI
 
 struct FindIdView: View {
+    @Environment(NavigationRouter<OnboardingRoute>.self) private var router
     
     @Environment(\.dismiss) var dismiss
     @StateObject private var viewModel = FindIdViewModel()
     @FocusState private var isFocused: Bool
     
     var body: some View {
-        NavigationStack {
-            ZStack {
-                Image(.imgOnboardingBackground)
-                    .resizable()
-                    .ignoresSafeArea()
-                    .onTapGesture { // 키보드 내리기 용도
-                        isFocused = false
-                    }
-                
-                VStack{
-                    Spacer().frame(height: 96)
-                    Image(.imgLogo)
-                        .resizable()
-                        .frame(width: 60, height: 36)
-                    Spacer().frame(height: 51)
-                    Text("Shoot Your")
-                        .textStyle(.Title_Text_Ko)
-                        .foregroundStyle(.white)
-                    Text("Core.")
-                        .textStyle(.Title_Text_Ko)
-                        .foregroundStyle(.white)
-                    
-                    Spacer().frame(height: 16)
-                    
-                    if viewModel.findedId {
-                        FindGroup
-                    } else {
-                        InputGroup
-                    }
-                    Spacer()
+        ZStack {
+            Image(.imgOnboardingBackground)
+                .resizable()
+                .ignoresSafeArea()
+                .onTapGesture { // 키보드 내리기 용도
+                    isFocused = false
                 }
+            
+            VStack{
+                Spacer().frame(height: 96)
+                Image(.imgLogo)
+                    .resizable()
+                    .frame(width: 60, height: 36)
+                Spacer().frame(height: 51)
+                Text("Shoot Your")
+                    .textStyle(.Title_Text_Ko)
+                    .foregroundStyle(.white)
+                Text("Core.")
+                    .textStyle(.Title_Text_Ko)
+                    .foregroundStyle(.white)
+                
+                Spacer().frame(height: 16)
+                
+                if viewModel.findedId {
+                    FindGroup
+                } else {
+                    InputGroup
+                }
+                Spacer()
             }
         }
         .navigationBarBackButtonHidden()
@@ -95,7 +94,9 @@ struct FindIdView: View {
             .disabled(viewModel.name.isEmpty || viewModel.email.isEmpty)
             
             Spacer().frame(height: 12)
-            NavigationLink(destination: LoginView()) {
+            Button(action: {
+                router.pop()
+            }) {
                 ZStack{
                     Rectangle()
                         .frame(height: 40)
@@ -110,7 +111,9 @@ struct FindIdView: View {
             Spacer().frame(height: 54)
             
             HStack{
-                NavigationLink(destination: SignupView()) {
+                Button(action: {
+                    router.push(.signup)
+                }) {
                     Text("회원가입")
                         .textStyle(.login_info)
                         .underline()
@@ -119,7 +122,9 @@ struct FindIdView: View {
                 
                 Spacer().frame(width: 32)
                 
-                NavigationLink(destination: FindPwView()) {
+                Button(action: {
+                    router.push(.findPw)
+                }) {
                     Text("비밀번호를 잊으셨나요?")
                         .textStyle(.login_info)
                         .underline()
@@ -161,7 +166,9 @@ struct FindIdView: View {
             Spacer().frame(height: 29)
             
             
-            NavigationLink(destination: FindPwView()) {
+            Button(action: {
+                router.push(.findPw)
+            }) {
                 ZStack{
                     Rectangle()
                         .frame(height: 40)
@@ -173,7 +180,9 @@ struct FindIdView: View {
                 }
             }
             
-            NavigationLink(destination: LoginView()) {
+            Button(action: {
+                router.pop()
+            }) {
                 ZStack{
                     Rectangle()
                         .frame(height: 40)

--- a/CoreDisc/Views/Onboarding/FindIdView.swift
+++ b/CoreDisc/Views/Onboarding/FindIdView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct FindIdView: View {
     @Environment(NavigationRouter<OnboardingRoute>.self) private var router
     
-    @Environment(\.dismiss) var dismiss
     @StateObject private var viewModel = FindIdViewModel()
     @FocusState private var isFocused: Bool
     

--- a/CoreDisc/Views/Onboarding/FindPwView.swift
+++ b/CoreDisc/Views/Onboarding/FindPwView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct FindPwView: View {
+    @Environment(NavigationRouter<OnboardingRoute>.self) private var router
     
     @Environment(\.dismiss) var dismiss
     @StateObject private var viewModel = FindPwViewModel()
@@ -17,7 +18,6 @@ struct FindPwView: View {
     @State private var rePwdShown = false
     
     var body: some View {
-        NavigationStack{
             ZStack {
                 Image(.imgOnboardingBackground)
                     .resizable()
@@ -50,8 +50,10 @@ struct FindPwView: View {
                     Spacer()
                 }
             }
-        }
         .navigationBarBackButtonHidden()
+        .fullScreenCover(isPresented: $viewModel.changeSuccess) {
+            LoginView()
+        }
     }
     private var InputGroup : some View{
         VStack{
@@ -91,7 +93,9 @@ struct FindPwView: View {
             
             Spacer().frame(height: 12)
             
-            NavigationLink(destination: LoginView()) {
+            Button(action: {
+                router.reset()
+            }) {
                 ZStack{
                     Rectangle()
                         .frame(height: 40)
@@ -146,7 +150,9 @@ struct FindPwView: View {
 
             Spacer().frame(height: 12)
             
-            NavigationLink(destination: LoginView()) {
+            Button(action: {
+                router.reset()
+            }) {
                 ZStack{
                     Rectangle()
                         .frame(height: 40)
@@ -268,11 +274,12 @@ struct FindPwView: View {
                 Text("변경하기")
             }, boxColor: (viewModel.pwd.isEmpty || viewModel.rePwd.isEmpty) ? .gray400 : .key)
             .disabled(viewModel.pwd.isEmpty || viewModel.rePwd.isEmpty)
-            .navigationDestination(isPresented: $viewModel.changeSuccess) {LoginView()}
             
             Spacer().frame(height: 12)
             
-            NavigationLink(destination: LoginView()) {
+            Button(action: {
+                router.reset()
+            }) {
                 ZStack{
                     Rectangle()
                         .frame(height: 40)

--- a/CoreDisc/Views/Onboarding/FindPwView.swift
+++ b/CoreDisc/Views/Onboarding/FindPwView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct FindPwView: View {
     @Environment(NavigationRouter<OnboardingRoute>.self) private var router
     
-    @Environment(\.dismiss) var dismiss
     @StateObject private var viewModel = FindPwViewModel()
     @FocusState private var isFocused: Bool
     

--- a/CoreDisc/Views/Onboarding/LoginView.swift
+++ b/CoreDisc/Views/Onboarding/LoginView.swift
@@ -9,37 +9,36 @@ import SwiftUI
 import Moya
 
 struct LoginView: View {
+    @Environment(NavigationRouter<OnboardingRoute>.self) private var router
     
     @StateObject private var viewModel = LoginViewModel()
     @FocusState private var isFocused: Bool
     
     var body: some View {
-        NavigationStack {
-            ZStack {
-                Image(.imgOnboardingBackground)
-                    .resizable()
-                    .ignoresSafeArea()
-                    .onTapGesture { // 키보드 내리기 용도
-                        isFocused = false
-                    }
-                
-                VStack{
-                    Image(.imgLogo)
-                        .resizable()
-                        .frame(width: 60, height: 36)
-                    Spacer().frame(height: 51)
-                    Text("Shoot Your")
-                        .textStyle(.Title_Text_Ko)
-                        .foregroundStyle(.white)
-                    Text("Core.")
-                        .textStyle(.Title_Text_Ko)
-                        .foregroundStyle(.white)
-                    
-                    Spacer().frame(height: 16)
-                    MainGroup
-                    Spacer().frame(height: 43)
-                    SocialLoginGroup
+        ZStack {
+            Image(.imgOnboardingBackground)
+                .resizable()
+                .ignoresSafeArea()
+                .onTapGesture { // 키보드 내리기 용도
+                    isFocused = false
                 }
+            
+            VStack{
+                Image(.imgLogo)
+                    .resizable()
+                    .frame(width: 60, height: 36)
+                Spacer().frame(height: 51)
+                Text("Shoot Your")
+                    .textStyle(.Title_Text_Ko)
+                    .foregroundStyle(.white)
+                Text("Core.")
+                    .textStyle(.Title_Text_Ko)
+                    .foregroundStyle(.white)
+                
+                Spacer().frame(height: 16)
+                MainGroup
+                Spacer().frame(height: 43)
+                SocialLoginGroup
             }
         }
         .fullScreenCover(isPresented: $viewModel.isLogin) {
@@ -90,12 +89,13 @@ struct LoginView: View {
                 Text("로그인")
             }, boxColor: (viewModel.username.isEmpty || viewModel.password.isEmpty) ? .gray400 : .key)
             .disabled(viewModel.username.isEmpty || viewModel.password.isEmpty)
-            .navigationDestination(isPresented: $viewModel.isLogin) {TabBar()}
             
             Spacer().frame(height: 37)
             
             HStack{
-                NavigationLink(destination: SignupView()) {
+                Button(action: {
+                    router.push(.signup)
+                }) {
                     Text("회원가입")
                         .textStyle(.login_info)
                         .underline()
@@ -104,7 +104,9 @@ struct LoginView: View {
                 
                 Spacer().frame(width: 32)
                 
-                NavigationLink(destination: FindIdView()) {
+                Button(action: {
+                    router.push(.findId)
+                }) {
                     Text("아이디/비밀번호 찾기")
                         .textStyle(.login_info)
                         .underline()

--- a/CoreDisc/Views/Onboarding/SignupView.swift
+++ b/CoreDisc/Views/Onboarding/SignupView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct SignupView: View {
     @Environment(NavigationRouter<OnboardingRoute>.self) private var router
     
-    @Environment(\.dismiss) var dismiss
     @StateObject private var viewModel = SignupViewModel()
     @FocusState private var isFocused: Bool
     
@@ -30,7 +29,7 @@ struct SignupView: View {
                 LazyVStack{
                     HStack{
                         Button(action: {
-                            dismiss()
+                            router.pop()
                         }){
                             Image(.imgGoback)
                                 .padding()

--- a/CoreDisc/Views/Onboarding/SignupView.swift
+++ b/CoreDisc/Views/Onboarding/SignupView.swift
@@ -8,57 +8,59 @@
 import SwiftUI
 
 struct SignupView: View {
+    @Environment(NavigationRouter<OnboardingRoute>.self) private var router
     
     @Environment(\.dismiss) var dismiss
     @StateObject private var viewModel = SignupViewModel()
     @FocusState private var isFocused: Bool
-
+    
     @State private var pwdShown = false
     @State private var rePwdShown = false
     @State private var TermsModal: Int? = 0
     
     var body: some View {
-        NavigationStack{
-            ZStack {
-                Image(.imgOnboardingBackground)
-                    .resizable()
-                    .ignoresSafeArea()
-                    .onTapGesture { // 키보드 내리기 용도
-                        isFocused = false
-                    }
-                ScrollView{
-                    LazyVStack{
-                        HStack{
-                            Button(action: {
-                                dismiss()
-                            }){
-                                Image(.imgGoback)
-                                    .padding()
-                            }
-                            Spacer()
+        ZStack {
+            Image(.imgOnboardingBackground)
+                .resizable()
+                .ignoresSafeArea()
+                .onTapGesture { // 키보드 내리기 용도
+                    isFocused = false
+                }
+            ScrollView{
+                LazyVStack{
+                    HStack{
+                        Button(action: {
+                            dismiss()
+                        }){
+                            Image(.imgGoback)
+                                .padding()
                         }
-                        Image(.imgLogo)
-                            .resizable()
-                            .frame(width: 60, height: 36)
-                        Spacer().frame(height: 31)
-                        MainGroup
                         Spacer()
                     }
-                }
-                if let id = TermsModal,
-                   let term = viewModel.termsList.first(where: { $0.termsId == id }) {
-                    TermsModalView(
-                        essential: term.isRequired,
-                        title: term.title,
-                        action: { TermsModal = nil },
-                        content: term.content
-                    )
+                    Image(.imgLogo)
+                        .resizable()
+                        .frame(width: 60, height: 36)
+                    Spacer().frame(height: 31)
+                    MainGroup
+                    Spacer()
                 }
             }
-            .navigationBarBackButtonHidden()
+            if let id = TermsModal,
+               let term = viewModel.termsList.first(where: { $0.termsId == id }) {
+                TermsModalView(
+                    essential: term.isRequired,
+                    title: term.title,
+                    action: { TermsModal = nil },
+                    content: term.content
+                )
+            }
         }
+        .navigationBarBackButtonHidden()
         .onAppear {
             viewModel.getTerms()
+        }
+        .fullScreenCover(isPresented: $viewModel.isSignedUp) {
+            LoginView()
         }
     }
     
@@ -139,7 +141,7 @@ struct SignupView: View {
             } else {
                 Spacer().frame(height: 28)
             }
-     
+            
             InputView{
                 TextField("인증번호를 입력해주세요.", text: $viewModel.code)
                     .focused($isFocused)
@@ -455,10 +457,6 @@ struct SignupView: View {
                 Text("가입하기")
             }, boxColor: (viewModel.email.isEmpty || viewModel.code.isEmpty || viewModel.password.isEmpty || viewModel.passwordCheck.isEmpty || viewModel.username.isEmpty || viewModel.name.isEmpty) ? .gray400 : .key)
             .disabled(viewModel.email.isEmpty || viewModel.code.isEmpty || viewModel.password.isEmpty || viewModel.passwordCheck.isEmpty || viewModel.username.isEmpty || viewModel.name.isEmpty)
-            
-            .navigationDestination(isPresented: $viewModel.isSignedUp) {
-                LoginView()
-            }
         }
         .padding(.horizontal, 41)
     }

--- a/CoreDisc/Views/Post/PostDetailView.swift
+++ b/CoreDisc/Views/Post/PostDetailView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import Kingfisher
 
 struct PostDetailView: View {
-    @Environment(\.dismiss) private var dismiss
+    @Environment(NavigationRouter<PostRoute>.self) private var router
     @StateObject private var viewModel = PostDetailViewModel()
     
     @State var showCommentSheet: Bool = false
@@ -84,20 +84,23 @@ struct PostDetailView: View {
         .task(id: viewModel.answersList.count) {
             currentQuestion = viewModel.cardItems.first?.question ?? ""
         }
-        .navigationDestination(isPresented: $showUserHome, destination: {
-            if isOwner {
-                MyHomeView()
-            } else {
-                UserHomeView(userName: commentUsername)
+        .onChange(of: showUserHome) {
+            if showUserHome {
+                if isOwner {
+                    router.push(.myHome)
+                } else {
+                    router.push(.user(userName: commentUsername))
+                }
+                showUserHome = false
             }
-        })
+        }
     }
     
     // 뒤로가기 버튼 섹션
     private var BackButtonGroup: some View {
         HStack{
             Button(action: {
-                dismiss()
+                router.pop()
             }){
                 Image(.iconBack)
                     .resizable()

--- a/CoreDisc/Views/Post/PostDiaryCheckView.swift
+++ b/CoreDisc/Views/Post/PostDiaryCheckView.swift
@@ -8,32 +8,37 @@
 import SwiftUI
 
 struct PostDiaryCheckView: View {
+    @Environment(NavigationRouter<WriteRoute>.self) private var router
+    
     @State private var isWriteButtonTapped = false
     @State private var isShareButtonTapped = false
     
     @State private var goToWriteDiary = false
     
+    @State private var isDone: Bool = false // 발행 -> 홈
+    
     var body: some View {
-        NavigationStack {
-            ZStack {
-                Image(.imgDiaryCheckBg)
-                    .resizable()
-                    .ignoresSafeArea()
+        ZStack {
+            Image(.imgDiaryCheckBg)
+                .resizable()
+                .ignoresSafeArea()
+            
+            VStack {
+                Spacer().frame(height: 65)
                 
-                VStack {
-                    Spacer().frame(height: 65)
-                    
-                    TitleGroup
-                    
-                    Spacer().frame(height: 56)
-                    
-                    ButtonGroup
-                    
-                    DiaryGroup
-                }
+                TitleGroup
+                
+                Spacer().frame(height: 56)
+                
+                ButtonGroup
+                
+                DiaryGroup
             }
         }
         .navigationBarBackButtonHidden()
+        .fullScreenCover(isPresented: $isDone) {
+            TabBar(startTab: .home)
+        }
     }
     
     // 타이틀
@@ -59,7 +64,9 @@ struct PostDiaryCheckView: View {
             HStack (spacing: 165){
                 ZStack {
                     // Write버튼(수정)
-                    NavigationLink(destination: PostWriteDiaryView()) {
+                    Button(action: {
+                        router.pop()
+                    }) {
                         EllipticalGradient(stops: [
                             .init(color: .gray.opacity(0.0), location: 0.2692),
                             .init(color: .white, location: 0.8125)
@@ -80,7 +87,9 @@ struct PostDiaryCheckView: View {
                 
                 // Share버튼
                 ZStack {
-                    NavigationLink(destination: PostMainView()) {
+                    Button(action: {
+                        isDone = true
+                    }) {
                         EllipticalGradient(stops: [
                             .init(color: .gray.opacity(0.0), location: 0.2692),
                             .init(color: .white, location: 0.8125)
@@ -101,7 +110,7 @@ struct PostDiaryCheckView: View {
             }
         }
     }
-
+    
     
     
     // 선택일기 요약
@@ -128,7 +137,7 @@ struct PostDiaryCheckView: View {
                 }
             )
             .offset(y: -20)
-
+            
             
             VStack (alignment: .center, spacing: 13) {
                 Spacer().frame(height: 28)

--- a/CoreDisc/Views/Post/PostDiaryCheckView.swift
+++ b/CoreDisc/Views/Post/PostDiaryCheckView.swift
@@ -37,7 +37,7 @@ struct PostDiaryCheckView: View {
         }
         .navigationBarBackButtonHidden()
         .fullScreenCover(isPresented: $isDone) {
-            TabBar(startTab: .home)
+            TabBar(startTab: .post)
         }
     }
     

--- a/CoreDisc/Views/Post/PostMainView.swift
+++ b/CoreDisc/Views/Post/PostMainView.swift
@@ -14,13 +14,13 @@ enum PostCategoryTap : String, CaseIterable {
 }
 
 struct PostMainView: View {
+    @Environment(NavigationRouter<PostRoute>.self) private var router
+    
     @StateObject private var viewModel = PostMainViewModel()
     @StateObject private var notiViewModel = NotificationViewModel()
     
     @State private var selectedTab: PostCategoryTap = .all
     @Namespace private var animation
-    @State private var searchQuery: String = ""
-    @State private var isSearch: Bool = false
     
     private var selectedPosts: [PostMain] {
         switch selectedTab {
@@ -32,19 +32,17 @@ struct PostMainView: View {
     }
     
     var body: some View {
-        NavigationStack {
-            ZStack{
-                Image(.imgPostDetailMainBg)
-                    .resizable()
-                    .ignoresSafeArea()
+        ZStack{
+            Image(.imgPostDetailMainBg)
+                .resizable()
+                .ignoresSafeArea()
+            
+            VStack(spacing: 0) {
+                TitleGroup
                 
-                VStack(spacing: 0) {
-                    TitleGroup
-                    
-                    CategoryGroup
-                    
-                    PostGroup
-                }
+                CategoryGroup
+                
+                PostGroup
             }
         }
         .onAppear {
@@ -65,7 +63,9 @@ struct PostMainView: View {
             
             Spacer()
             
-            NavigationLink(destination: SearchView(query: $searchQuery, isSearch: $isSearch)) {
+            Button(action: {
+                router.push(.search)
+            }) {
                 ZStack {
                     Color.clear
                         .frame(width: 48, height: 48)
@@ -77,7 +77,9 @@ struct PostMainView: View {
                 }
             }
             
-            NavigationLink(destination: NotificationView()) {
+            Button(action: {
+                router.push(.notification)
+            }) {
                 ZStack(alignment: .topTrailing) {
                     Image(.iconAlert)
                         .resizable()
@@ -129,10 +131,14 @@ struct PostMainView: View {
 
 // 게시물 카드
 struct PostCard: View {
+    @Environment(NavigationRouter<PostRoute>.self) private var router
+    
     var item: PostMain
     
     var body: some View {
-        NavigationLink(destination: PostDetailView(postId: item.postId)) {
+        Button(action: {
+            router.push(.detail(postId: item.postId))
+        }) {
             ZStack(alignment: .top) {
                 Rectangle()
                     .frame(width: 164)
@@ -232,7 +238,6 @@ struct PostCard: View {
 }
 
 // 카테고리 메뉴바 커스텀
-// TODO: 메뉴바 디자인 완료시 수정 예정
 struct PostTopTabView: View {
     @Binding var selectedTab: PostCategoryTap
     var animation: Namespace.ID
@@ -268,8 +273,6 @@ struct PostTopTabView: View {
     }
 }
 
-
-#Preview {
-    PostMainView()
-}
-
+//#Preview {
+//    PostMainView()
+//}

--- a/CoreDisc/Views/Post/PostWriteDiaryView.swift
+++ b/CoreDisc/Views/Post/PostWriteDiaryView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct PostWriteDiaryView: View {
+    @Environment(NavigationRouter<WriteRoute>.self) private var router
+    
     @State private var selectedWho: String = "나혼자"
     @State private var selectedWhere: String = "집"
     @State private var selectedWhat: String = "공부"
@@ -24,25 +26,23 @@ struct PostWriteDiaryView: View {
     @State private var moreChoice: Bool? = nil
     @State private var moreText: String = ""
     
-
+    
     
     var body: some View {
-        NavigationStack {
-            ZStack {
-                Image(.imgPostDetailMainBg)
-                    .resizable()
-                    .ignoresSafeArea()
-                
-                ScrollView (showsIndicators: false) {
-                    VStack {
-                        Spacer().frame(height: 25)
-                        
-                        TitleGroup
-                        
-                        Spacer().frame(height: 18)
-                        
-                        DiaryGroup
-                    }
+        ZStack {
+            Image(.imgPostDetailMainBg)
+                .resizable()
+                .ignoresSafeArea()
+            
+            ScrollView (showsIndicators: false) {
+                VStack {
+                    Spacer().frame(height: 25)
+                    
+                    TitleGroup
+                    
+                    Spacer().frame(height: 18)
+                    
+                    DiaryGroup
                 }
             }
         }
@@ -131,8 +131,8 @@ struct PostWriteDiaryView: View {
                             
                             Button (action: {
                                 withAnimation(.easeInOut(duration: 0.15)) {
-                                                                selection.wrappedValue = item
-                                                            }
+                                    selection.wrappedValue = item
+                                }
                             }){
                                 Text(item)
                                     .textStyle(.Small_Text)
@@ -220,8 +220,8 @@ struct PostWriteDiaryView: View {
                             
                             Button (action: {
                                 withAnimation(.easeInOut(duration: 0.15)) {
-                                                                selection.wrappedValue = item
-                                                            }
+                                    selection.wrappedValue = item
+                                }
                             }){
                                 Text(item)
                                     .textStyle(.Small_Text)
@@ -336,7 +336,9 @@ struct PostWriteDiaryView: View {
                         
                         Spacer().frame(width: 8)
                         
-                        NavigationLink(destination: PostDiaryCheckView()) {
+                        Button(action: {
+                            router.push(.summary)
+                        }) {
                             ZStack {
                                 Circle()
                                     .frame(width: 32, height: 32)

--- a/CoreDisc/Views/Post/PostWriteView.swift
+++ b/CoreDisc/Views/Post/PostWriteView.swift
@@ -15,6 +15,8 @@ struct CardContent {
 }
 
 struct PostWriteView: View {
+    @Environment(NavigationRouter<WriteRoute>.self) private var router
+    
     @StateObject private var viewModel = PostpostsViewModel()
     @State private var selectedDate = Date()
     
@@ -38,31 +40,29 @@ struct PostWriteView: View {
     @State private var selectedPhotoItem: PhotosPickerItem? = nil
     
     var body: some View {
-        NavigationStack{
-            ZStack {
-                Image(.imgShortBackground)
-                    .resizable()
-                    .ignoresSafeArea()
+        ZStack {
+            Image(.imgShortBackground)
+                .resizable()
+                .ignoresSafeArea()
+            
+            VStack {
+                Spacer().frame(height: 22)
                 
-                VStack {
-                    Spacer().frame(height: 22)
-                    
-                    UserGroup
-                    
-                    Spacer().frame(height: 33)
-                    
-                    PostGroup
-                    
-                    Spacer().frame(height: 49)
-                    
-                    QuestionGroup
-                    
-                    Spacer().frame(height: 19)
-                    
-                    BottomGroup
-                    
-                    Spacer()
-                }
+                UserGroup
+                
+                Spacer().frame(height: 33)
+                
+                PostGroup
+                
+                Spacer().frame(height: 49)
+                
+                QuestionGroup
+                
+                Spacer().frame(height: 19)
+                
+                BottomGroup
+                
+                Spacer()
             }
         }
         .navigationBarBackButtonHidden()
@@ -250,7 +250,9 @@ struct PostWriteView: View {
             }
             
             // 넘어가기 버튼
-            NavigationLink(destination: PostWriteDiaryView()) {
+            Button(action: {
+                router.push(.select)
+            }) {
                 ZStack {
                     Circle()
                         .frame(width: nextDiameter, height: nextDiameter)
@@ -319,7 +321,7 @@ struct PostWriteView: View {
                                 .foregroundColor(.black)
                                 .scrollContentBackground(.hidden)
                                 .frame(width: 263)
-                                .frame(maxHeight: 356) 
+                                .frame(maxHeight: 356)
                         }
                     }
                     .padding(.all, 18)

--- a/CoreDisc/Views/Question/QuestionBasicView.swift
+++ b/CoreDisc/Views/Question/QuestionBasicView.swift
@@ -8,12 +8,11 @@
 import SwiftUI
 
 struct QuestionBasicView: View {
+    @Environment(NavigationRouter<QuestionRoute>.self) private var router
+    
     @StateObject private var viewModel = QuestionBasicViewModel()
-    @ObservedObject var mainViewModel: QuestionMainViewModel
     
     let selectedQuestionType: String
-    
-    @Environment(\.dismiss) var dismiss
     @State var goToMain: Bool = false
     
     @FocusState private var isFocused: Bool
@@ -64,7 +63,6 @@ struct QuestionBasicView: View {
                     order: order,
                     selectedQuestionType: .DEFAULT,
                     viewModel: viewModel,
-                    mainViewModel: mainViewModel,
                     showSelectModal: $showSelectModal,
                     goToMain: $goToMain
                 )
@@ -121,7 +119,7 @@ struct QuestionBasicView: View {
             
             VStack(alignment: .leading, spacing: 9) {
                 Button(action: {
-                    dismiss()
+                    router.pop()
                 }) {
                     Image(.iconBack)
                 }

--- a/CoreDisc/Views/Question/QuestionBasicView.swift
+++ b/CoreDisc/Views/Question/QuestionBasicView.swift
@@ -105,7 +105,7 @@ struct QuestionBasicView: View {
             let keyword = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
             viewModel.fetchSearchCategories(keyword: keyword)
         }
-        .fullScreenCover(isPresented: $goToMain) { TabBar(startTab: .disk) }
+        .fullScreenCover(isPresented: $goToMain) { TabBar(startTab: .question) }
     }
     
     // MARK: - group

--- a/CoreDisc/Views/Question/QuestionListView.swift
+++ b/CoreDisc/Views/Question/QuestionListView.swift
@@ -72,7 +72,7 @@ struct QuestionListView: View {
             fetchQuestions(reset: true)
         }
         .navigationBarBackButtonHidden()
-        .fullScreenCover(isPresented: $goToMain) { TabBar(startTab: .disk) }
+        .fullScreenCover(isPresented: $goToMain) { TabBar(startTab: .question) }
     }
 
     private var TopGroup: some View {

--- a/CoreDisc/Views/Question/QuestionListView.swift
+++ b/CoreDisc/Views/Question/QuestionListView.swift
@@ -13,7 +13,6 @@ struct QuestionListView: View {
     @StateObject private var viewModel = QuestionListViewModel()
     @StateObject private var selectViewModel = QuestionBasicViewModel()
     
-    @Environment(\.dismiss) var dismiss
     @State var isSaveMode: Bool
     @State private var selectedCategoryId: Int? = 0 // 0 = All
     @State private var categoryUUID = UUID()
@@ -78,7 +77,9 @@ struct QuestionListView: View {
 
     private var TopGroup: some View {
         VStack(alignment: .leading, spacing: 7) {
-            Button(action: { dismiss() }) {
+            Button(action: {
+                router.pop()
+            }) {
                 Image(.iconBack)
             }
 

--- a/CoreDisc/Views/Question/QuestionListView.swift
+++ b/CoreDisc/Views/Question/QuestionListView.swift
@@ -8,9 +8,10 @@
 import SwiftUI
 
 struct QuestionListView: View {
+    @Environment(NavigationRouter<QuestionRoute>.self) private var router
+    
     @StateObject private var viewModel = QuestionListViewModel()
     @StateObject private var selectViewModel = QuestionBasicViewModel()
-    @ObservedObject var mainViewModel: QuestionMainViewModel
     
     @Environment(\.dismiss) var dismiss
     @State var isSaveMode: Bool
@@ -63,7 +64,6 @@ struct QuestionListView: View {
                     order: order,
                     selectedQuestionType: .OFFICIAL,
                     viewModel: selectViewModel,
-                    mainViewModel: mainViewModel,
                     showSelectModal: $showSelectModal,
                     goToMain: $goToMain
                 )

--- a/CoreDisc/Views/Question/QuestionMainView.swift
+++ b/CoreDisc/Views/Question/QuestionMainView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct QuestionMainView: View {
+    @Environment(NavigationRouter<QuestionRoute>.self) private var router
+    
     @StateObject var viewModel = QuestionMainViewModel()
     
     @State var isSelectView: Bool = false
@@ -20,21 +22,19 @@ struct QuestionMainView: View {
     let timer = Timer.publish(every: 0.02, on: .main, in: .common).autoconnect()
     
     var body: some View {
-        NavigationStack {
-            ZStack {
-                Image(.imgShortBackground)
-                    .resizable()
-                    .ignoresSafeArea()
-                    
-                VStack {
-                    TitleGroup
-                    
-                    Spacer().frame(height: 36)
-                    
-                    MainCDGroup
-                    
-                    Spacer()
-                }
+        ZStack {
+            Image(.imgShortBackground)
+                .resizable()
+                .ignoresSafeArea()
+            
+            VStack {
+                TitleGroup
+                
+                Spacer().frame(height: 36)
+                
+                MainCDGroup
+                
+                Spacer()
             }
         }
         .task {
@@ -112,7 +112,7 @@ struct QuestionMainView: View {
                 startColor: colors(for: question1?.questionType).0,
                 endColor: colors(for: question1?.questionType).1
             )
-                .position(x: 150+79, y: 97)
+            .position(x: 150+79, y: 97)
             
             QuestionSelectItem(
                 moveLeft: $isSelectView,
@@ -123,7 +123,7 @@ struct QuestionMainView: View {
                 startColor: colors(for: question2?.questionType).0,
                 endColor: colors(for: question2?.questionType).1
             )
-                .position(x: 150+34, y: 196)
+            .position(x: 150+34, y: 196)
             
             QuestionSelectItem(
                 moveLeft: $isSelectView,
@@ -134,7 +134,7 @@ struct QuestionMainView: View {
                 startColor: colors(for: question3?.questionType).0,
                 endColor: colors(for: question3?.questionType).1
             )
-                .position(x: 150+42, y: 295)
+            .position(x: 150+42, y: 295)
             
             QuestionSelectItem(
                 moveLeft: $isSelectView,
@@ -145,7 +145,7 @@ struct QuestionMainView: View {
                 startColor: colors(for: question4?.questionType).0,
                 endColor: colors(for: question4?.questionType).1
             )
-                .position(x: 150+79, y: 394)
+            .position(x: 150+79, y: 394)
             
             SelectCDGroup
                 .offset(x: 460)
@@ -156,18 +156,10 @@ struct QuestionMainView: View {
     
     private var SelectCDGroup: some View {
         VStack(spacing: 22) {
-            QuestionSelectButton(title: "질문 작성") {
-                QuestionWriteView()
-            }
-            QuestionSelectButton(title: "기본 질문") {
-                QuestionBasicView(mainViewModel: viewModel, selectedQuestionType: currentQuestionType, order: currentOrder)
-            }
-            QuestionSelectButton(title: "인기 질문") {
-                QuestionTrendingView(mainViewModel: viewModel, selectedQuestionType: currentQuestionType, order: currentOrder)
-            }
-            QuestionSelectButton(title: "공유/저장\n질문") {
-                QuestionShareNowView(mainViewModel: viewModel, selectedQuestionType: currentQuestionType, order: currentOrder)
-            }
+            QuestionSelectButton(title: "질문 작성", destination: .write)
+            QuestionSelectButton(title: "기본 질문", destination: .basic)
+            QuestionSelectButton(title: "인기 질문", destination: .trending)
+            QuestionSelectButton(title: "공유/저장\n질문", destination: .shareNow)
         }
         .offset(x: 0)
     }
@@ -219,33 +211,33 @@ struct QuestionSelectItem: View {
 }
 
 // 질문 선택 버튼 컴포넌트
-struct QuestionSelectButton<Destination: View>: View {
+struct QuestionSelectButton: View {
+    @Environment(NavigationRouter<QuestionRoute>.self) private var router
+    
     var title: String
-    var destination: (() -> Destination)?
+    var destination: QuestionRoute
     
     var body: some View {
-        if let destination = destination {
-            NavigationLink(destination: destination()) {
-                buttonContent
-            }
-        } else {
+        Button(action: {
+            router.push(destination)
+        }) {
             buttonContent
         }
     }
-
+    
     private var buttonContent: some View {
         ZStack(alignment: .top) {
             Image(.imgCd)
                 .resizable()
                 .frame(width: 76, height: 76)
                 .shadow(color: .black.opacity(0.25), radius: 2, x: 0, y: 4)
-
+            
             ZStack(alignment: .topLeading) {
                 RoundedRectangle(cornerRadius: 4)
                     .horizontalLinearGradient(startColor: .white, endColor: .gray400)
                     .frame(width: 98, height: 68)
                     .shadow(color: .black.opacity(0.25), radius: 2, x: 0, y: 4)
-
+                
                 Text(title)
                     .textStyle(.Q_Main)
                     .foregroundStyle(.black000)

--- a/CoreDisc/Views/Question/QuestionMainView.swift
+++ b/CoreDisc/Views/Question/QuestionMainView.swift
@@ -14,7 +14,6 @@ struct QuestionMainView: View {
     
     @State var isSelectView: Bool = false
     @State var currentOrder: Int = 0
-    
     @State var currentQuestionType: String = ""
     
     // 씨디 돌아가는 애니메이션
@@ -157,9 +156,9 @@ struct QuestionMainView: View {
     private var SelectCDGroup: some View {
         VStack(spacing: 22) {
             QuestionSelectButton(title: "질문 작성", destination: .write)
-            QuestionSelectButton(title: "기본 질문", destination: .basic)
-            QuestionSelectButton(title: "인기 질문", destination: .trending)
-            QuestionSelectButton(title: "공유/저장\n질문", destination: .shareNow)
+            QuestionSelectButton(title: "기본 질문", destination: .basic(selectedQuestionType: currentQuestionType, order: currentOrder))
+            QuestionSelectButton(title: "인기 질문", destination: .trending(selectedQuestionType: currentQuestionType, order: currentOrder))
+            QuestionSelectButton(title: "공유/저장\n질문", destination: .shareNow(selectedQuestionType: currentQuestionType, order: currentOrder))
         }
         .offset(x: 0)
     }

--- a/CoreDisc/Views/Question/QuestionShareNowView.swift
+++ b/CoreDisc/Views/Question/QuestionShareNowView.swift
@@ -67,7 +67,7 @@ struct QuestionShareNowView: View {
         .task {
             await viewModel.fetchMySharedQuestions()
         }
-        .fullScreenCover(isPresented: $goToMain) { TabBar(startTab: .disk) }
+        .fullScreenCover(isPresented: $goToMain) { TabBar(startTab: .question) }
     }
     
     private var InfoGroup: some View {

--- a/CoreDisc/Views/Question/QuestionShareNowView.swift
+++ b/CoreDisc/Views/Question/QuestionShareNowView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct QuestionShareNowView: View {
+    @Environment(NavigationRouter<QuestionRoute>.self) private var router
+    
     @StateObject private var viewModel = SharedQuestionViewModel()
     @StateObject private var selectViewModel = QuestionBasicViewModel()
     
@@ -16,7 +18,6 @@ struct QuestionShareNowView: View {
     @Environment(\.dismiss) var dismiss
     @State private var goToMain = false
     
-    @ObservedObject var mainViewModel: QuestionMainViewModel
     let selectedQuestionType: String
     let order: Int
     
@@ -40,7 +41,6 @@ struct QuestionShareNowView: View {
             VStack {
                 Spacer()
                 NavigationLink(destination: QuestionListView(
-                    mainViewModel: mainViewModel,
                     isSaveMode: true,
                     selectedQuestionType: selectedQuestionType,
                     order: order)
@@ -59,7 +59,6 @@ struct QuestionShareNowView: View {
                     order: order,
                     selectedQuestionType: .OFFICIAL,
                     viewModel: selectViewModel,
-                    mainViewModel: mainViewModel,
                     showSelectModal: $showSelectModal,
                     goToMain: $goToMain
                 )
@@ -85,7 +84,6 @@ struct QuestionShareNowView: View {
                 Spacer()
                 
                 NavigationLink(destination: QuestionListView(
-                    mainViewModel: mainViewModel,
                     isSaveMode: false,
                     selectedQuestionType: selectedQuestionType,
                     order: order)

--- a/CoreDisc/Views/Question/QuestionShareNowView.swift
+++ b/CoreDisc/Views/Question/QuestionShareNowView.swift
@@ -15,7 +15,6 @@ struct QuestionShareNowView: View {
     
     private let spacingAngle: Double = 19
     @State private var hiddenCount = 0
-    @Environment(\.dismiss) var dismiss
     @State private var goToMain = false
     
     let selectedQuestionType: String
@@ -75,7 +74,7 @@ struct QuestionShareNowView: View {
         VStack(alignment: .leading, spacing: 7) {
             HStack {
                 Button(action: {
-                    dismiss()
+                    router.pop()
                 }) {
                     Image(.iconBack)
                 }

--- a/CoreDisc/Views/Question/QuestionSummaryView.swift
+++ b/CoreDisc/Views/Question/QuestionSummaryView.swift
@@ -143,7 +143,7 @@ struct QuestionSummaryView: View {
             
             // 공유하기
             PrimaryActionButton(title: "작성한 질문 공유하기", isFinished: .constant(true))
-                .fullScreenCover(isPresented: $isShareSuccess) { TabBar(startTab: .disk) }
+                .fullScreenCover(isPresented: $isShareSuccess) { TabBar(startTab: .question) }
                 .simultaneousGesture(
                     TapGesture().onEnded {
                         viewModel.shareOfficialQuestion(

--- a/CoreDisc/Views/Question/QuestionSummaryView.swift
+++ b/CoreDisc/Views/Question/QuestionSummaryView.swift
@@ -7,11 +7,11 @@
 import SwiftUI
 
 struct QuestionSummaryView: View {
-    @Environment(\.dismiss) var dismiss
+    @Environment(NavigationRouter<QuestionRoute>.self) private var router
     
-    @Binding var questionId: Int?
-    @Binding var selectedCategory: CategoryType?
-    @Binding var text: String
+    let questionId: Int?
+    let selectedCategory: CategoryType?
+    @State var text: String
     
     @StateObject private var viewModel = QuestionSummaryViewModel()
     @StateObject private var sharedQuestionVM = SharedQuestionViewModel()
@@ -25,7 +25,7 @@ struct QuestionSummaryView: View {
                 .ignoresSafeArea()
             VStack {
                 HStack {
-                    Button(action: { dismiss() }) {
+                    Button(action: { router.pop() }) {
                         Image(.iconBack)
                     }
                     .padding(.leading, 17)
@@ -161,7 +161,7 @@ struct QuestionSummaryView: View {
             
             
             Button {
-                dismiss() // 기존 WriteView로 돌아가기
+                router.pop() // 기존 WriteView로 돌아가기
             } label: {
                 PrimaryActionButton(title: "질문 재작성하기", isFinished: .constant(true))
             }

--- a/CoreDisc/Views/Question/QuestionTrendingView.swift
+++ b/CoreDisc/Views/Question/QuestionTrendingView.swift
@@ -9,12 +9,13 @@ import SwiftUI
 
 
 struct QuestionTrendingView: View {
+    @Environment(NavigationRouter<QuestionRoute>.self) private var router
+    
     @Environment(\.dismiss) var dismiss
     @State var goToMain: Bool = false
     
     @StateObject private var viewModel = PopularQuestionViewModel()
     @StateObject private var basicviewModel = QuestionBasicViewModel()
-    @ObservedObject var mainViewModel: QuestionMainViewModel
     
     let selectedQuestionType: String
     
@@ -48,7 +49,6 @@ struct QuestionTrendingView: View {
                     order: order,
                     selectedQuestionType: .OFFICIAL,
                     viewModel: basicviewModel,
-                    mainViewModel: mainViewModel,
                     showSelectModal: $showSelectModal,
                     goToMain: $goToMain
                 )

--- a/CoreDisc/Views/Question/QuestionTrendingView.swift
+++ b/CoreDisc/Views/Question/QuestionTrendingView.swift
@@ -57,7 +57,7 @@ struct QuestionTrendingView: View {
         .task {
             viewModel.fetchPopularQuestions()
         }
-        .fullScreenCover(isPresented: $goToMain) { TabBar(startTab: .disk) }
+        .fullScreenCover(isPresented: $goToMain) { TabBar(startTab: .question) }
     }
     
     

--- a/CoreDisc/Views/Question/QuestionTrendingView.swift
+++ b/CoreDisc/Views/Question/QuestionTrendingView.swift
@@ -11,7 +11,6 @@ import SwiftUI
 struct QuestionTrendingView: View {
     @Environment(NavigationRouter<QuestionRoute>.self) private var router
     
-    @Environment(\.dismiss) var dismiss
     @State var goToMain: Bool = false
     
     @StateObject private var viewModel = PopularQuestionViewModel()
@@ -66,7 +65,7 @@ struct QuestionTrendingView: View {
         VStack(alignment: .leading) {
             HStack {
                 Button(action:{
-                    dismiss()
+                    router.pop()
                 }) {
                     Image(.iconBack)
                         .resizable()

--- a/CoreDisc/Views/Question/QuestionWriteView.swift
+++ b/CoreDisc/Views/Question/QuestionWriteView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct QuestionWriteView: View {
     @Environment(NavigationRouter<QuestionRoute>.self) private var router
-    @Environment(\.dismiss) var dismiss
     
     @State var questionId: Int? = nil
     @State var selectedCategory: CategoryType? = nil
@@ -60,7 +59,7 @@ struct QuestionWriteView: View {
         VStack{
             HStack {
                 Button(action: {
-                    dismiss()
+                    router.pop()
                 }){
                     Image(.iconBack)
                 }

--- a/CoreDisc/Views/Question/QuestionWriteView.swift
+++ b/CoreDisc/Views/Question/QuestionWriteView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct QuestionWriteView: View {
+    @Environment(NavigationRouter<QuestionRoute>.self) private var router
     @Environment(\.dismiss) var dismiss
     
     @State var questionId: Int? = nil
@@ -27,29 +28,17 @@ struct QuestionWriteView: View {
                 QuestionCaution
                 Spacer().frame(height: 43)
                 
-                if let selectedCategory = selectedCategory {
-                    NavigationLink(
-                        destination: QuestionSummaryView(
-                            questionId: $questionId,
-                            selectedCategory: $selectedCategory,
-                            text: $text
-                        ),
-                        label: {
-                            PrimaryActionButton(
-                                title: "확인 및 저장",
-                                isFinished: .constant(!text.isEmpty)
-                            )
-                        }
-                    )
-                    .disabled(text.isEmpty)
-                    .padding(.horizontal, 21)
-                } else {
+                Button(action: {
+                    guard let category = selectedCategory, !text.isEmpty else { return }
+                    router.push(.summary(questionId: questionId, selectedCategory: category, text: text))
+                }) {
                     PrimaryActionButton(
                         title: "확인 및 저장",
-                        isFinished: .constant(false)
+                        isFinished: .constant(!(selectedCategory == nil || text.isEmpty))
                     )
-                    .padding(.horizontal, 21)
                 }
+                .disabled(selectedCategory == nil || text.isEmpty)
+                .padding(.horizontal, 21)
             }
             .onTapGesture { isFocused = false }
             Spacer().frame(height: 43)

--- a/CoreDisc/Views/Report/ChangeCoverView.swift
+++ b/CoreDisc/Views/Report/ChangeCoverView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct ChangeCoverView: View {
     @Environment(NavigationRouter<ReportRoute>.self) private var router
     
-    @Environment(\.dismiss) var dismiss
     @StateObject var viewModel = ReportMainViewModel()
     private let columns: [GridItem] = Array(repeating: GridItem(.fixed(80), spacing: 26), count: 3)
     @State var cover: String = ""
@@ -25,7 +24,7 @@ struct ChangeCoverView: View {
             VStack{
                 HStack{
                     Button(action: {
-                        dismiss()
+                        router.pop()
                     }){
                         Image(.imgGoback)
                             .padding()
@@ -92,7 +91,7 @@ struct ChangeCoverView: View {
             })
             .onChange(of: viewModel.colorChangeSuccess) { oldValue, newValue in
                 if newValue {
-                    dismiss()
+                    router.pop()
                 }
             }
         }

--- a/CoreDisc/Views/Report/ChangeCoverView.swift
+++ b/CoreDisc/Views/Report/ChangeCoverView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct ChangeCoverView: View {
+    @Environment(NavigationRouter<ReportRoute>.self) private var router
+    
     @Environment(\.dismiss) var dismiss
     @StateObject var viewModel = ReportMainViewModel()
     private let columns: [GridItem] = Array(repeating: GridItem(.fixed(80), spacing: 26), count: 3)

--- a/CoreDisc/Views/Report/ReportDetailView.swift
+++ b/CoreDisc/Views/Report/ReportDetailView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct ReportDetailView: View {
+    @Environment(NavigationRouter<ReportRoute>.self) private var router
     
     @Environment(\.dismiss) var dismiss
     @State private var nowIndex: Int = 1
@@ -63,50 +64,48 @@ struct ReportDetailView: View {
     
     
     var body: some View {
-        NavigationStack{
-            ZStack {
-                Image(.imgLongBackground)
-                    .resizable()
-                    .ignoresSafeArea()
-                
-                VStack {
-                    ScrollView(.vertical) {
-                        LazyVStack {
-                            HeaderGroup
-                            TotalDiscGroup
-                                .highPriorityGesture(
-                                    DragGesture(minimumDistance: 5)
-                                        .onEnded { value in
-                                            if value.translation.height < -5 {
-                                                if DiscQuestionViewModel.hasNextPage {
-                                                    animatePageChange {
-                                                        DiscQuestionViewModel.nextPage()
-                                                    }
-                                                } else {
+        ZStack {
+            Image(.imgLongBackground)
+                .resizable()
+                .ignoresSafeArea()
+            
+            VStack {
+                ScrollView(.vertical) {
+                    LazyVStack {
+                        HeaderGroup
+                        TotalDiscGroup
+                            .highPriorityGesture(
+                                DragGesture(minimumDistance: 5)
+                                    .onEnded { value in
+                                        if value.translation.height < -5 {
+                                            if DiscQuestionViewModel.hasNextPage {
+                                                animatePageChange {
                                                     DiscQuestionViewModel.nextPage()
                                                 }
-                                            } else if value.translation.height > 5 {
-                                                if DiscQuestionViewModel.hasPreviousPage {
-                                                    animatePageChange {
-                                                        DiscQuestionViewModel.previousPage()
-                                                    }
-                                                } else {
+                                            } else {
+                                                DiscQuestionViewModel.nextPage()
+                                            }
+                                        } else if value.translation.height > 5 {
+                                            if DiscQuestionViewModel.hasPreviousPage {
+                                                animatePageChange {
                                                     DiscQuestionViewModel.previousPage()
                                                 }
+                                            } else {
+                                                DiscQuestionViewModel.previousPage()
                                             }
                                         }
-                                )
-                            Spacer().frame(height: 64)
-                            RandomGroup
-                            Spacer().frame(height: 64)
-                            TimeReportGroup
-                            Spacer().frame(height: 44)
-                            GoSummaryGroup
-                        }
-                        .padding(.bottom, 107)
+                                    }
+                            )
+                        Spacer().frame(height: 64)
+                        RandomGroup
+                        Spacer().frame(height: 64)
+                        TimeReportGroup
+                        Spacer().frame(height: 44)
+                        GoSummaryGroup
                     }
-                    PresentGroup
+                    .padding(.bottom, 107)
                 }
+                PresentGroup
             }
             .task {
                 viewModel.getReport(year: year, month: month)
@@ -287,7 +286,9 @@ struct ReportDetailView: View {
     
     private var GoSummaryGroup: some View {
         VStack {
-            NavigationLink(destination: ReportSummaryView(SummaryYear: year, SummaryMonth: month)){
+            Button(action: {
+                router.push(.summary(SummaryYear: year, SummaryMonth: month))
+            }){
                 ZStack {
                     RoundedRectangle(cornerRadius: 16)
                         .foregroundStyle(.white)
@@ -354,7 +355,9 @@ struct ReportDetailView: View {
                 Spacer()
                 
                 HStack {
-                    NavigationLink(destination: ReportDetailView(year: beforeDiscYear, month: beforeDiscMonth)){
+                    Button(action: {
+                        router.push(.detail(year: beforeDiscYear, month: beforeDiscMonth))
+                    }){
                         Image(.iconBefore)
                     }
                     Spacer().frame(width: 19)
@@ -363,7 +366,9 @@ struct ReportDetailView: View {
                     Image(.iconPlay)
                     Spacer().frame(width: 19)
                     
-                    NavigationLink(destination: ReportDetailView(year: nextDiscYear, month: nextDiscMonth)){
+                    Button(action: {
+                        router.push(.detail(year: nextDiscYear, month: nextDiscMonth))
+                    }){
                         Image(.iconNext)
                     }
                 }

--- a/CoreDisc/Views/Report/ReportDetailView.swift
+++ b/CoreDisc/Views/Report/ReportDetailView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct ReportDetailView: View {
     @Environment(NavigationRouter<ReportRoute>.self) private var router
     
-    @Environment(\.dismiss) var dismiss
     @State private var nowIndex: Int = 1
     
     @StateObject private var viewModel = ReportDetailViewModel()
@@ -134,7 +133,7 @@ struct ReportDetailView: View {
             Image(.imgReportHeaderIcon)
             
             Button(action: {
-                dismiss()
+                router.pop()
             }){
                 Image(.imgGoback)
             }

--- a/CoreDisc/Views/Report/ReportMainView.swift
+++ b/CoreDisc/Views/Report/ReportMainView.swift
@@ -9,52 +9,50 @@ import SwiftUI
 import Kingfisher
 
 struct ReportMainView: View {
+    @Environment(NavigationRouter<ReportRoute>.self) private var router
     
     @StateObject private var viewModel = ReportMainViewModel()
     private let columns: [GridItem] = Array(repeating: GridItem(.fixed(91), spacing: 27), count: 3)
     @State private var edit = false
     
     var body: some View {
-        NavigationStack{
+        ZStack {
+            Image(.imgShortBackground2)
+                .resizable()
+                .ignoresSafeArea()
             
-            ZStack {
-                Image(.imgShortBackground2)
-                    .resizable()
-                    .ignoresSafeArea()
-                
-                VStack{
-                    HStack{
-                        Image(.imgReportHeaderIcon)
-                            .resizable()
-                            .frame(width: 14, height: 55)
-
-                        Spacer()
-                    }
+            VStack{
+                HStack{
+                    Image(.imgReportHeaderIcon)
+                        .resizable()
+                        .frame(width: 14, height: 55)
                     
-                    HStack{
-                        Text(" Disc Museum")
-                            .textStyle(.Title_Text_Eng)
-                            .foregroundStyle(.white)
-                            .padding(.leading, 25)
-                        Spacer()
-                        Button(action:{edit.toggle()}, label:{
-                            if edit {
-                                Image(.imgDiscOn)
-                                    .resizable()
-                                    .frame(width: 60, height: 44)
-                            } else {
-                                Image(.imgDiscOff)
-                                    .resizable()
-                                    .frame(width: 60, height: 44)
-                            }
-                        })
-                        
-                        Spacer().frame(width: 14)
-                    }
-                    
-                    Spacer().frame(height: 11)
-                    DiscGroup
+                    Spacer()
                 }
+                
+                HStack{
+                    Text(" Disc Museum")
+                        .textStyle(.Title_Text_Eng)
+                        .foregroundStyle(.white)
+                        .padding(.leading, 25)
+                    Spacer()
+                    Button(action:{edit.toggle()}, label:{
+                        if edit {
+                            Image(.imgDiscOn)
+                                .resizable()
+                                .frame(width: 60, height: 44)
+                        } else {
+                            Image(.imgDiscOff)
+                                .resizable()
+                                .frame(width: 60, height: 44)
+                        }
+                    })
+                    
+                    Spacer().frame(width: 14)
+                }
+                
+                Spacer().frame(height: 11)
+                DiscGroup
             }
         }
         .task {
@@ -67,7 +65,9 @@ struct ReportMainView: View {
             LazyVGrid(columns: columns){
                 ForEach(viewModel.DiscList){ item in
                     if edit {
-                        NavigationLink(destination: ChangeCoverView(discId: item.id)){
+                        Button(action: {
+                            router.push(.cover(discId: item.id))
+                        }){
                             ZStack{
                                 DiscItem(
                                     imageUrl: item.imageUrl,
@@ -79,7 +79,9 @@ struct ReportMainView: View {
                             }
                         }
                     } else {
-                        NavigationLink(destination: ReportDetailView(year: item.year, month: item.month)){
+                        Button(action: {
+                            router.push(.detail(year: item.year, month: item.month))
+                        }){
                             DiscItem(
                                 imageUrl: item.imageUrl,
                                 localImageName: item.localImageName,

--- a/CoreDisc/Views/Report/ReportSummaryView.swift
+++ b/CoreDisc/Views/Report/ReportSummaryView.swift
@@ -8,7 +8,8 @@
 import SwiftUI
 
 struct ReportSummaryView: View {
-    @Environment(\.dismiss) var dismiss
+    @Environment(NavigationRouter<ReportRoute>.self) private var router
+    
     @State private var currentIndex: Int = 0
     @StateObject private var viewModel = ReportSummaryViewModel()
     
@@ -62,7 +63,7 @@ struct ReportSummaryView: View {
         HStack{
             Image(.imgReportHeaderIcon)
             Button(action: {
-                dismiss()
+                router.pop()
             }){
                 Image(.imgGoback)
             }

--- a/CoreDisc/Views/Search/SearchView.swift
+++ b/CoreDisc/Views/Search/SearchView.swift
@@ -8,30 +8,25 @@
 import SwiftUI
 
 struct SearchView: View {
-    @Binding var query:String
-    @Binding var isSearch: Bool
+    @State var query: String = ""
+    @State var isSearch: Bool = false
     @State private var path = NavigationPath()
     @StateObject private var viewModel = SearchHistoryViewModel()
     
     var body: some View {
-        NavigationStack(path: $path) {
-            ZStack {
-                Image(.imgSearchBackground)
-                    .resizable()
-                    .ignoresSafeArea()
-                
-                VStack {
-                    Spacer().frame(height: 11)
-                    SearchBarGroup(query: $query, isSearch: $isSearch, onSearch: {
-                        path.append(UUID())
-                    })
-                    Spacer().frame(height: isSearch ? 18 : 21)
-                    SearchGroup
-                    Spacer()
-                }
-            }
-            .navigationDestination(for: UUID.self) { _ in
-                SearchResultView(query: $query, isSearch: $isSearch, path: $path)
+        ZStack {
+            Image(.imgSearchBackground)
+                .resizable()
+                .ignoresSafeArea()
+            
+            VStack {
+                Spacer().frame(height: 11)
+                SearchBarGroup(query: $query, isSearch: $isSearch, onSearch: {
+                    path.append(UUID())
+                })
+                Spacer().frame(height: isSearch ? 18 : 21)
+                SearchGroup
+                Spacer()
             }
         }
         .task {
@@ -87,16 +82,16 @@ struct RecentItem: View {
     let text: String
     var isDeleting: Bool = false
     var onDelete: () -> Void = {}
-
+    
     var body: some View {
         HStack {
             Text(text)
                 .textStyle(.Q_Main)
                 .foregroundStyle(.white)
                 .padding(.leading, 30)
-
+            
             Spacer()
-
+            
             if isDeleting {
                 ProgressView()
                     .frame(width: 24, height: 24)
@@ -107,7 +102,7 @@ struct RecentItem: View {
                         .padding(.trailing, 36)
                         .frame(width: 24, height: 24)
                         .foregroundStyle(.white)
-                        
+                    
                 }
             }
         }
@@ -116,16 +111,6 @@ struct RecentItem: View {
     }
 }
 
-
-private struct SearchViewPreviewWrapper: View {
-    @State var tempQuery = ""
-    @State var tempSearch = false
-    
-    var body: some View {
-        SearchView(query: $tempQuery, isSearch: $tempSearch)
-    }
-}
-
-#Preview {
-    SearchViewPreviewWrapper()
-}
+//#Preview {
+//    SearchView()
+//}

--- a/CoreDisc/Views/TabBar.swift
+++ b/CoreDisc/Views/TabBar.swift
@@ -42,7 +42,7 @@ struct TabBar: View {
                 case .write:
                     WriteTabContainer()
                 case .disk:
-                    QuestionMainView()
+                    QuestionTabContainer()
                 case .report:
                     ReportMainView()
                 case .mypage:

--- a/CoreDisc/Views/TabBar.swift
+++ b/CoreDisc/Views/TabBar.swift
@@ -40,7 +40,7 @@ struct TabBar: View {
                 case .home:
                     PostTabContainer()
                 case .write:
-                    PostWriteView()
+                    WriteTabContainer()
                 case .disk:
                     QuestionMainView()
                 case .report:

--- a/CoreDisc/Views/TabBar.swift
+++ b/CoreDisc/Views/TabBar.swift
@@ -44,7 +44,7 @@ struct TabBar: View {
                 case .disk:
                     QuestionTabContainer()
                 case .report:
-                    ReportMainView()
+                    ReportTabContainer()
                 case .mypage:
                     MyHomeView()
                 }

--- a/CoreDisc/Views/TabBar.swift
+++ b/CoreDisc/Views/TabBar.swift
@@ -46,7 +46,7 @@ struct TabBar: View {
                 case .report:
                     ReportTabContainer()
                 case .mypage:
-                    MyHomeView()
+                    MyhomeTabContainer()
                 }
             }
             .environmentObject(tabBarVisibility)

--- a/CoreDisc/Views/TabBar.swift
+++ b/CoreDisc/Views/TabBar.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 enum Tab {
-    case home, write, disk, report, mypage
+    case post, write, question, report, myhome
 }
 
 enum TabBarStyle {
@@ -16,19 +16,19 @@ enum TabBarStyle {
 }
 
 struct TabBar: View {
-    @State private var selectedTab: Tab = .disk
+    @State private var selectedTab: Tab = .question
     @State private var tabBarStyle: TabBarStyle = .light
     @StateObject private var tabBarVisibility = TabBarVisibility()
     
-    init(startTab: Tab = .disk) {
+    init(startTab: Tab = .question) {
         _selectedTab = State(initialValue: startTab)
         _tabBarStyle = State(initialValue: {
             switch startTab {
-            case .home: return .dark
-            case .write: return .dark
-            case .disk: return .light
+            case .post: return .dark
+            case .write: return .light
+            case .question: return .light
             case .report: return .light
-            case .mypage: return .light
+            case .myhome: return .light
             }
         }())
     }
@@ -37,15 +37,15 @@ struct TabBar: View {
         ZStack(alignment: .bottom) {
             Group {
                 switch selectedTab {
-                case .home:
+                case .post:
                     PostTabContainer()
                 case .write:
                     WriteTabContainer()
-                case .disk:
+                case .question:
                     QuestionTabContainer()
                 case .report:
                     ReportTabContainer()
-                case .mypage:
+                case .myhome:
                     MyhomeTabContainer()
                 }
             }
@@ -70,11 +70,11 @@ struct TabBar: View {
     
     private func tabBarStyle(for tab: Tab) -> TabBarStyle {
         switch tab {
-        case .home: .dark
-        case .write: .dark
-        case .disk: .light
+        case .post: .dark
+        case .write: .light
+        case .question: .light
         case .report: .light
-        case .mypage: .light
+        case .myhome: .light
         }
     }
 }
@@ -94,11 +94,11 @@ struct CustomTabBar: View {
                     .padding(.horizontal, 24)
                 
                 HStack(spacing: 19) {
-                    TabBarItem(selectedTab: $selectedTab, tabBarStyle: tabBarStyle, tab: .home, icon: "icon_home")
+                    TabBarItem(selectedTab: $selectedTab, tabBarStyle: tabBarStyle, tab: .post, icon: "icon_home")
                     TabBarItem(selectedTab: $selectedTab, tabBarStyle: tabBarStyle, tab: .write, icon: "icon_pencil")
-                    TabBarItem(selectedTab: $selectedTab, tabBarStyle: tabBarStyle, tab: .disk, icon: "icon_disk")
+                    TabBarItem(selectedTab: $selectedTab, tabBarStyle: tabBarStyle, tab: .question, icon: "icon_disk")
                     TabBarItem(selectedTab: $selectedTab, tabBarStyle: tabBarStyle, tab: .report, icon: "icon_museum")
-                    TabBarItem(selectedTab: $selectedTab, tabBarStyle: tabBarStyle, tab: .mypage, icon: "icon_mypage")
+                    TabBarItem(selectedTab: $selectedTab, tabBarStyle: tabBarStyle, tab: .myhome, icon: "icon_mypage")
                 }
             }
         }

--- a/CoreDisc/Views/TabBar.swift
+++ b/CoreDisc/Views/TabBar.swift
@@ -38,7 +38,7 @@ struct TabBar: View {
             Group {
                 switch selectedTab {
                 case .home:
-                    PostMainView()
+                    PostTabContainer()
                 case .write:
                     PostWriteView()
                 case .disk:


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용
[ 작업한 내용을 작성해주세요 ( UI 구현이라면 사진도 같이 올려주시면 좋아요! ) ]
- 탭바 리팩토링

## 📋 추후 진행 상황
[ 다음에 진행할 작업에 대해 작성해주세요!! ]</br>
[ 현재 커밋 후 풀리퀘 다음으로 작업 내용을 적어주면 됩니다! ]
- 게시글 API 수정 후 반영

## 📌 리뷰 포인트
[ 어떤 부분을 잘 체크해야하는지 작성해주세요 ]



## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [x] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 온보딩 전용 네비게이션 컨테이너 도입 및 앱 시작 화면을 온보딩 화면으로 변경
  - 탭 구조 개편: 탭 이름 재정의(post/write/question/report/myhome)와 탭별 독립 네비게이션 도입, 탭 재선택 시 해당 흐름 초기화
  - 알림·게시글·질문·리포트·마이홈 전반에 라우터 기반 화면 전환 적용
- 버그 수정
  - 일부 알림 데이터 누락 시에도 목록이 안정적으로 표시되도록 복원력 개선
- 리팩터
  - NavigationLink/NavigationStack 의존 제거, 프로그램적 라우팅으로 일관된 뒤로가기/전환 동작
  - 여러 화면의 레이아웃 단순화 및 전체 화면 전환 사용 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->