### PR TITLE
🐛 Fix: 저장 질문 조회 및 삭제 API 연동

### DIFF
--- a/CoreDisc/API/Router/QuestionRouter.swift
+++ b/CoreDisc/API/Router/QuestionRouter.swift
@@ -40,7 +40,7 @@ enum QuestionRouter {
     ) // 기본 질문 리스트 조회 (검색)
     
     case deletePersonal(questionId: Int) // 작성하여 저장한 질문 삭제하기 (커스텀 질문 삭제)
-    case deleteOfficial(questionId: Int) // 저장한 공유질문 삭제
+    case deleteOfficial(savedId: Int) // 저장한 공유질문 삭제
     case getPopular(selectedQuestionType: String) // 인기 질문 조회
     case patchPersonal(questionId: Int, categoryIdList: [Int], question: String) // 작성 질문 재작성
     
@@ -79,8 +79,8 @@ extension QuestionRouter: APITargetType {
             
         case .deletePersonal(let questionId):
             return "\(Self.questionPath)/personal/\(questionId)"
-        case .deleteOfficial(let questionId):
-            return "\(Self.questionPath)/official/saved/\(questionId)"
+        case .deleteOfficial(let savedId):
+            return "\(Self.questionPath)/official/saved/\(savedId)"
         case .getPopular:
             return "\(Self.questionPath)/popular"
         case .patchPersonal(let questionId, _, _):
@@ -133,7 +133,7 @@ extension QuestionRouter: APITargetType {
             if let size = size { params["size"] = size }
             return .requestParameters(parameters: params, encoding: URLEncoding.queryString)
         case .getOfficialSavedMine(let categoryId, let cursorId, let size):
-            var params: [String: Any] = ["selectedQuestionType": "OFFICIAL"]
+            var params: [String: Any] = [:]
             if let categoryId = categoryId, categoryId != 0 {
                 params["categoryId"] = categoryId
             }
@@ -144,6 +144,7 @@ extension QuestionRouter: APITargetType {
                 params["size"] = size
             }
             return .requestParameters(parameters: params, encoding: URLEncoding.queryString)
+
         case .getCategories:
             return .requestPlain
         case .getCategoriesSearch(let keyword):

--- a/CoreDisc/Responses/Question/QuestionListResponse.swift
+++ b/CoreDisc/Responses/Question/QuestionListResponse.swift
@@ -20,8 +20,13 @@ struct QuestionListResult: Codable {
 }
 
 struct QuestionListItem: Codable, Identifiable {
-    let id: Int
+
+    var id: Int { savedId }
+
+    let savedId: Int        // 커서 용 id
+    let questionId: Int     // 실제 질문 id
     let categories: [QuestionListCategory]
+    let questionType: String  // "DEFAULT", "PERSONAL", "OFFICIAL"
     let question: String
     let sharedCount: Int
     let isSelected: Bool
@@ -32,4 +37,5 @@ struct QuestionListCategory: Codable {
     let categoryId: Int
     let categoryName: String
 }
+
 

--- a/CoreDisc/Views/Question/QuestionListView.swift
+++ b/CoreDisc/Views/Question/QuestionListView.swift
@@ -125,14 +125,15 @@ struct QuestionListView: View {
                             sharedCount: item.sharedCount,
                             index: list.firstIndex(where: { $0.id == item.id })! + 1,
                             onDelete: {
-                                viewModel.deleteOfficialSaved(questionId: item.id) { success in
+                                viewModel.deleteOfficialSaved(savedId: item.savedId) { success in
                                     if success {
                                         if var currentList = viewModel.questionListMap[categoryUUID] {
-                                            currentList.removeAll(where: { $0.id == item.id })
+                                            currentList.removeAll { $0.savedId == item.savedId }
                                             viewModel.questionListMap[categoryUUID] = currentList
                                         }
                                     }
                                 }
+
                             },
                             onTap: {
                                 showSelectModal = true


### PR DESCRIPTION
## ✨ PR 유형

어떤 변경 사항이 있나요??

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 사용자 UI 디자인 변경 및 추가
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 🛠️ 작업내용
[ 작업한 내용을 작성해주세요 ( UI 구현이라면 사진도 같이 올려주시면 좋아요! ) ]
- 저장 질문 조회 및 삭제 API 연동

## 📋 추후 진행 상황
[ 다음에 진행할 작업에 대해 작성해주세요!! ]</br>
[ 현재 커밋 후 풀리퀘 다음으로 작업 내용을 적어주면 됩니다! ]

## 📌 리뷰 포인트
[ 어떤 부분을 잘 체크해야하는지 작성해주세요 ]



## ✅ Checklist

PR이 다음 요구 사항을 충족하는지 확인해주세요!!!

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다
    -  해당 링크 : [깃 모지 컨벤션](https://tngusmiso.tistory.com/57)
- [X] 유지-보수를 위해 주석처리를 잘 작성하였는가?
    - 해당 링크 : [Xcode 주석 정리](https://yoojin99.github.io/app/Swift-Documentation/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 공식 저장 질문 삭제 후 목록이 즉시 정확히 갱신되지 않던 문제를 수정했습니다.
  * 페이징 상태(hasNext) 반영 오류를 해결해 더 보기/무한 스크롤 동작을 안정화했습니다.
  * 기본 필터 적용으로 결과가 불필요하게 제한되던 현상을 해소해 목록 노출을 개선했습니다.
  * 실패 상황의 안내 문구를 일관되고 이해하기 쉽게 정비해 사용자 피드백을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->